### PR TITLE
Add DSS send functionality to deposit function

### DIFF
--- a/awd/deposit.py
+++ b/awd/deposit.py
@@ -3,15 +3,23 @@ import logging
 
 from botocore.exceptions import ClientError
 
-from awd import crossref, s3, wiley
-from awd.s3 import S3
+from awd import crossref, s3, sqs, wiley
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def deposit(doi_spreadsheet_path, metadata_url, content_url, bucket):
-    s3_client = S3()
+def deposit(
+    doi_spreadsheet_path,
+    metadata_url,
+    content_url,
+    bucket,
+    sqs_input_url,
+    sqs_output_url,
+    collection_handle,
+):
+    s3_client = s3.S3()
+    sqs_client = sqs.SQS()
     dois = crossref.get_dois_from_spreadsheet(doi_spreadsheet_path)
     for doi in dois:
         crossref_work_record = crossref.get_work_record_from_doi(metadata_url, doi)
@@ -25,19 +33,30 @@ def deposit(doi_spreadsheet_path, metadata_url, content_url, bucket):
         if wiley.is_valid_response(doi, wiley_response) is False:
             continue
         doi_file_name = doi.replace("/", "-")  # 10.1002/term.3131 to 10.1002-term.3131
-        package_files = s3.create_files_dict(
+        files_dict = s3.create_files_dict(
             doi_file_name, json.dumps(metadata), wiley_response.content
         )
         try:
-            for file in package_files:
+            for file in files_dict:
                 s3_client.put_file(file["file_content"], bucket, file["file_name"])
         except ClientError as e:
             logger.error(
                 f"Upload failed: {file['file_name']}, {e.response['Error']['Message']}"
             )
             continue
-        # create dss message
-        # submit dss message
+        bitstream_s3_uri = f"s3://{bucket}/{doi_file_name}.pdf"
+        metadata_s3_uri = f"s3://{bucket}/{doi_file_name}.json"
+        dss_message_attributes = sqs.create_dss_message_attributes(
+            doi_file_name, "wiley", sqs_output_url
+        )
+        dss_message_body = sqs.create_dss_message_body(
+            "DSpace",
+            collection_handle,
+            metadata_s3_uri,
+            f"{doi_file_name}.pdf",
+            bitstream_s3_uri,
+        )
+        sqs_client.send(sqs_input_url, dss_message_attributes, dss_message_body)
     return "Submission process has completed"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,12 +27,12 @@ def s3_mock(aws_credentials):
 
 
 @pytest.fixture(scope="function")
-def sqs_client():
+def sqs_class():
     return SQS()
 
 
 @pytest.fixture(scope="function")
-def s3_client():
+def s3_class():
     return S3()
 
 
@@ -106,7 +106,7 @@ def result_message_body():
         "lastModified": "Thu Sep 09 17:56:39 UTC 2021",
         "Bitstreams": [
             {
-                "BitstreamName": "baker_report.pdf",
+                "BitstreamName": "10.1002-term.3131.pdf",
                 "BitstreamUUID": "a1b2c3d4e5",
                 "BitstreamChecksum": {
                     "value": "a4e0f4930dfaff904fa3c6c85b0b8ecc",
@@ -133,11 +133,11 @@ def submission_message_body():
     submission_message_body = {
         "SubmissionSystem": "DSpace",
         "CollectionHandle": "123.4/5678",
-        "MetadataLocation": "mock://bucket/456.json",
+        "MetadataLocation": "s3://awd/10.1002-term.3131.json",
         "Files": [
             {
-                "BitstreamName": "456.pdf",
-                "FileLocation": "mock://bucket/456.pdf",
+                "BitstreamName": "10.1002-term.3131.pdf",
+                "FileLocation": "s3://awd/10.1002-term.3131.pdf",
                 "BitstreamDescription": None,
             }
         ],

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -1,63 +1,90 @@
 import logging
 
+import boto3
+from moto import mock_sqs
+
 from awd import deposit
-from awd.s3 import S3
 
 logger = logging.getLogger(__name__)
 
 
-def test_deposit_success(web_mock, s3_mock, s3_client):
-    s3 = S3()
+@mock_sqs
+def test_deposit_success(
+    web_mock, s3_mock, s3_class, sqs_class, submission_message_body
+):
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    sqs.create_queue(QueueName="mock-input-queue")
     response = deposit.deposit(
         "tests/fixtures/doi_success.csv",
         "http://example.com/works/",
         "http://example.com/doi/",
         "awd",
+        "https://queue.amazonaws.com/123456789012/mock-input-queue",
+        "https://queue.amazonaws.com/123456789012/mock-output-queue",
+        "123.4/5678",
     )
-    uploaded_metadata = s3.client.get_object(Bucket="awd", Key="10.1002-term.3131.json")
+    uploaded_metadata = s3_class.client.get_object(
+        Bucket="awd", Key="10.1002-term.3131.json"
+    )
     assert uploaded_metadata["ResponseMetadata"]["HTTPStatusCode"] == 200
-    uploaded_bitstream = s3.client.get_object(Bucket="awd", Key="10.1002-term.3131.pdf")
+    uploaded_bitstream = s3_class.client.get_object(
+        Bucket="awd", Key="10.1002-term.3131.pdf"
+    )
     assert uploaded_bitstream["ResponseMetadata"]["HTTPStatusCode"] == 200
+    messages = sqs_class.receive(
+        "https://queue.amazonaws.com/123456789012/mock-input-queue"
+    )
+    for message in messages:
+        assert message["Body"] == str(submission_message_body)
     assert response == "Submission process has completed"
 
 
-def test_deposit_insufficient_metadata(caplog, web_mock, s3_mock, s3_client):
+def test_deposit_insufficient_metadata(caplog, web_mock, s3_mock, s3_class):
     with caplog.at_level(logging.INFO):
         response = deposit.deposit(
             "tests/fixtures/doi_insufficient_metadata.csv",
             "http://example.com/works/",
             "http://example.com/doi/",
             "awd",
+            "mock-input-queue",
+            "mock-output-queue",
+            "123.4/5678",
         )
         assert (
             "Insufficient metadata for 10.1002/nome.tadata, missing title or URL"
             in caplog.text
         )
-        assert "Contents" not in s3_client.client.list_objects(Bucket="awd")
+        assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
         assert response == "Submission process has completed"
 
 
-def test_deposit_pdf_unavailable(caplog, web_mock, s3_mock, s3_client):
+def test_deposit_pdf_unavailable(caplog, web_mock, s3_mock, s3_class):
     with caplog.at_level(logging.INFO):
         response = deposit.deposit(
             "tests/fixtures/doi_pdf_unavailable.csv",
             "http://example.com/works/",
             "http://example.com/doi/",
             "awd",
+            "mock-input-queue",
+            "mock-output-queue",
+            "123.4/5678",
         )
         assert "A PDF could not be retrieved for DOI: 10.1002/none.0000" in caplog.text
-        assert "Contents" not in s3_client.client.list_objects(Bucket="awd")
+        assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
         assert response == "Submission process has completed"
 
 
-def test_deposit_s3_upload_failed(caplog, web_mock, s3_mock, s3_client):
+def test_deposit_s3_upload_failed(caplog, web_mock, s3_mock, s3_class):
     with caplog.at_level(logging.INFO):
         response = deposit.deposit(
             "tests/fixtures/doi_success.csv",
             "http://example.com/works/",
             "http://example.com/doi/",
             "not-a-bucket",
+            "mock-input-queue",
+            "mock-output-queue",
+            "123.4/5678",
         )
     assert "Upload failed: 10.1002-term.3131.json" in caplog.text
-    assert "Contents" not in s3_client.client.list_objects(Bucket="awd")
+    assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
     assert response == "Submission process has completed"

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,17 +1,17 @@
 from awd import s3
-from awd.s3 import S3
 
 
-def test_s3_put_file(s3_mock):
-    s3 = S3()
-    assert "Contents" not in s3.client.list_objects(Bucket="awd")
-    s3.put_file(
+def test_s3_put_file(s3_mock, s3_class):
+    assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
+    s3_class.put_file(
         str({"metadata": {"key": "dc.title", "value": "A Title"}}),
         "awd",
         "test.json",
     )
-    assert len(s3.client.list_objects(Bucket="awd")["Contents"]) == 1
-    assert s3.client.list_objects(Bucket="awd")["Contents"][0]["Key"] == "test.json"
+    assert len(s3_class.client.list_objects(Bucket="awd")["Contents"]) == 1
+    assert (
+        s3_class.client.list_objects(Bucket="awd")["Contents"][0]["Key"] == "test.json"
+    )
 
 
 def test_create_files_dict():

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -7,32 +7,30 @@ from awd import sqs
 
 
 @mock_sqs
-def test_sqs_receive_success(
-    sqs_client, result_message_attributes, result_message_body
-):
+def test_sqs_receive_success(sqs_class, result_message_attributes, result_message_body):
     sqs = boto3.resource("sqs", region_name="us-east-1")
     sqs_queue = sqs.create_queue(QueueName="mock-output-queue")
-    sqs_client.send(sqs_queue.url, {}, result_message_body)
-    messages = sqs_client.receive(sqs_queue.url)
+    sqs_class.send(sqs_queue.url, {}, result_message_body)
+    messages = sqs_class.receive(sqs_queue.url)
     for message in messages:
         assert message["Body"] == str(result_message_body)
 
 
 @mock_sqs
-def test_sqs_receive_failure(sqs_client):
+def test_sqs_receive_failure(sqs_class):
     with pytest.raises(ClientError):
-        messages = sqs_client.receive("non-existent")
+        messages = sqs_class.receive("non-existent")
         for message in messages:
             pass
 
 
 @mock_sqs
 def test_sqs_send_success(
-    sqs_client, submission_message_attributes, submission_message_body
+    sqs_class, submission_message_attributes, submission_message_body
 ):
     sqs = boto3.resource("sqs", region_name="us-east-1")
     sqs_queue = sqs.create_queue(QueueName="mock-input-queue")
-    response = sqs_client.send(
+    response = sqs_class.send(
         sqs_queue.url, submission_message_attributes, submission_message_body
     )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -40,10 +38,10 @@ def test_sqs_send_success(
 
 @mock_sqs
 def test_sqs_send_failure(
-    sqs_client, submission_message_attributes, submission_message_body
+    sqs_class, submission_message_attributes, submission_message_body
 ):
     with pytest.raises(ClientError):
-        sqs_client.send(
+        sqs_class.send(
             "non-existent", submission_message_attributes, submission_message_body
         )
 
@@ -59,8 +57,8 @@ def test_create_dss_message_body(submission_message_body):
     dss_message_body = sqs.create_dss_message_body(
         "DSpace",
         "123.4/5678",
-        "mock://bucket/456.json",
-        "456.pdf",
-        "mock://bucket/456.pdf",
+        "s3://awd/10.1002-term.3131.json",
+        "10.1002-term.3131.pdf",
+        "s3://awd/10.1002-term.3131.pdf",
     )
     assert dss_message_body == submission_message_body


### PR DESCRIPTION
#### What does this PR do?
The first commit refactors the testing code in preparation for testing the completed `deposit` function:
* Rename s3_client and sqs_client fixtures for greater accuracy
* Remove unnecessary imports
* Rename fixture attributes to align with integration test

The second commit updates the `deposit` function:
* Update deposit function to send message to DSS
* Add arguments to deposit function
* Rename package_files var to correspond with new name of function

#### Helpful background context
This completes the functionality of the `deposit` function. A separate function will be created to receive messages from the DSS results output queue which will complete the basic functionality of the entire process

#### How can a reviewer manually see the effects of these changes?
Run unit tests with `pipenv run pytest`

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
