### PR TITLE
Add click

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,4 +24,5 @@ moto = "*"
 python_version = "3.9"
 
 [scripts]
-awd = "python -c \"from awd.deposit import deposit; deposit()\""
+deposit = "python -c \"from awd.deposit import deposit; deposit()\""
+listen = "python -c \"from awd.listen import listen; listen()\""

--- a/awd/deposit.py
+++ b/awd/deposit.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import click
 from botocore.exceptions import ClientError
 
 from awd import crossref, s3, sqs, wiley
@@ -9,6 +10,47 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+@click.command()
+@click.option(
+    "--doi_spreadsheet_path",
+    required=True,
+    help="The path of the spreadsheet containing DOIs to be searched.",
+)
+@click.option(
+    "--metadata_url",
+    required=True,
+    help="The URL of the metadata records.",
+)
+@click.option(
+    "--content_url",
+    required=True,
+    help="The URL of the content files.",
+)
+@click.option(
+    "--bucket",
+    required=True,
+    help="The bucket to which content and metadata files will be uploaded.",
+)
+@click.option(
+    "--sqs_base_url",
+    required=True,
+    help="The base URL of the SQS queues.",
+)
+@click.option(
+    "--sqs_input_queue",
+    required=True,
+    help="The SQS queue to which submission messages will be sent.",
+)
+@click.option(
+    "--sqs_output_queue",
+    required=True,
+    help="The SQS queue from which results messages will be received.",
+)
+@click.option(
+    "--collection_handle",
+    required=True,
+    help="The handle of the DSpace collection to which items will be added.",
+)
 def deposit(
     doi_spreadsheet_path,
     metadata_url,
@@ -63,7 +105,7 @@ def deposit(
             dss_message_attributes,
             dss_message_body,
         )
-    return "Submission process has completed"
+    logger.info("Submission process has completed")
 
 
 if __name__ == "__main__":

--- a/awd/listen.py
+++ b/awd/listen.py
@@ -1,5 +1,6 @@
 import logging
 
+import click
 from botocore.exceptions import ClientError
 
 from awd.sqs import SQS
@@ -8,6 +9,17 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+@click.command()
+@click.option(
+    "--sqs_base_url",
+    required=True,
+    help="The base URL of the SQS queues.",
+)
+@click.option(
+    "--sqs_output_queue",
+    required=True,
+    help="The SQS queue from which results messages will be received.",
+)
 def listen(sqs_base_url, sqs_output_queue):
     sqs = SQS()
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import boto3
 import pytest
 import requests_mock
+from click.testing import CliRunner
 from moto import mock_s3
 
 from awd.s3 import S3
@@ -128,6 +129,11 @@ def result_success_message_body():
         ],
     }
     return result_success_message_body
+
+
+@pytest.fixture(scope="function")
+def runner():
+    return CliRunner()
 
 
 @pytest.fixture()

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -3,92 +3,141 @@ import logging
 import boto3
 from moto import mock_sqs
 
-from awd import deposit
+from awd.deposit import deposit
 
 logger = logging.getLogger(__name__)
 
 
 @mock_sqs
 def test_deposit_success(
-    web_mock, s3_mock, s3_class, sqs_class, submission_message_body
+    caplog, web_mock, s3_mock, s3_class, sqs_class, submission_message_body, runner
 ):
-    sqs = boto3.resource("sqs", region_name="us-east-1")
-    sqs.create_queue(QueueName="mock-input-queue")
-    response = deposit.deposit(
-        "tests/fixtures/doi_success.csv",
-        "http://example.com/works/",
-        "http://example.com/doi/",
-        "awd",
-        "https://queue.amazonaws.com/123456789012/",
-        "mock-input-queue",
-        "mock-output-queue",
-        "123.4/5678",
-    )
-    uploaded_metadata = s3_class.client.get_object(
-        Bucket="awd", Key="10.1002-term.3131.json"
-    )
-    assert uploaded_metadata["ResponseMetadata"]["HTTPStatusCode"] == 200
-    uploaded_bitstream = s3_class.client.get_object(
-        Bucket="awd", Key="10.1002-term.3131.pdf"
-    )
-    assert uploaded_bitstream["ResponseMetadata"]["HTTPStatusCode"] == 200
-    messages = sqs_class.receive(
-        "https://queue.amazonaws.com/123456789012/", "mock-input-queue"
-    )
-    for message in messages:
-        assert message["Body"] == str(submission_message_body)
-    assert response == "Submission process has completed"
-
-
-def test_deposit_insufficient_metadata(caplog, web_mock, s3_mock, s3_class):
-    with caplog.at_level(logging.INFO):
-        response = deposit.deposit(
-            "tests/fixtures/doi_insufficient_metadata.csv",
-            "http://example.com/works/",
-            "http://example.com/doi/",
-            "awd",
-            "https://queue.amazonaws.com/123456789012/",
-            "mock-input-queue",
-            "mock-output-queue",
-            "123.4/5678",
+    with caplog.at_level(logging.DEBUG):
+        sqs = boto3.resource("sqs", region_name="us-east-1")
+        sqs.create_queue(QueueName="mock-input-queue")
+        result = runner.invoke(
+            deposit,
+            [
+                "--doi_spreadsheet_path",
+                "tests/fixtures/doi_success.csv",
+                "--metadata_url",
+                "http://example.com/works/",
+                "--content_url",
+                "http://example.com/doi/",
+                "--bucket",
+                "awd",
+                "--sqs_base_url",
+                "https://queue.amazonaws.com/123456789012/",
+                "--sqs_input_queue",
+                "mock-input-queue",
+                "--sqs_output_queue",
+                "mock-output-queue",
+                "--collection_handle",
+                "123.4/5678",
+            ],
         )
+        assert result.exit_code == 0
+        uploaded_metadata = s3_class.client.get_object(
+            Bucket="awd", Key="10.1002-term.3131.json"
+        )
+        assert uploaded_metadata["ResponseMetadata"]["HTTPStatusCode"] == 200
+        uploaded_bitstream = s3_class.client.get_object(
+            Bucket="awd", Key="10.1002-term.3131.pdf"
+        )
+        assert uploaded_bitstream["ResponseMetadata"]["HTTPStatusCode"] == 200
+        messages = sqs_class.receive(
+            "https://queue.amazonaws.com/123456789012/", "mock-input-queue"
+        )
+        for message in messages:
+            assert message["Body"] == submission_message_body
+        assert "Submission process has completed" in caplog.text
+
+
+def test_deposit_insufficient_metadata(caplog, web_mock, s3_mock, s3_class, runner):
+    with caplog.at_level(logging.DEBUG):
+        result = runner.invoke(
+            deposit,
+            [
+                "--doi_spreadsheet_path",
+                "tests/fixtures/doi_insufficient_metadata.csv",
+                "--metadata_url",
+                "http://example.com/works/",
+                "--content_url",
+                "http://example.com/doi/",
+                "--bucket",
+                "awd",
+                "--sqs_base_url",
+                "https://queue.amazonaws.com/123456789012/",
+                "--sqs_input_queue",
+                "mock-input-queue",
+                "--sqs_output_queue",
+                "mock-output-queue",
+                "--collection_handle",
+                "123.4/5678",
+            ],
+        )
+        assert result.exit_code == 0
         assert (
             "Insufficient metadata for 10.1002/nome.tadata, missing title or URL"
             in caplog.text
         )
         assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
-        assert response == "Submission process has completed"
+        assert "Submission process has completed" in caplog.text
 
 
-def test_deposit_pdf_unavailable(caplog, web_mock, s3_mock, s3_class):
-    with caplog.at_level(logging.INFO):
-        response = deposit.deposit(
-            "tests/fixtures/doi_pdf_unavailable.csv",
-            "http://example.com/works/",
-            "http://example.com/doi/",
-            "awd",
-            "https://queue.amazonaws.com/123456789012/",
-            "mock-input-queue",
-            "mock-output-queue",
-            "123.4/5678",
+def test_deposit_pdf_unavailable(caplog, web_mock, s3_mock, s3_class, runner):
+    with caplog.at_level(logging.DEBUG):
+        result = runner.invoke(
+            deposit,
+            [
+                "--doi_spreadsheet_path",
+                "tests/fixtures/doi_pdf_unavailable.csv",
+                "--metadata_url",
+                "http://example.com/works/",
+                "--content_url",
+                "http://example.com/doi/",
+                "--bucket",
+                "awd",
+                "--sqs_base_url",
+                "https://queue.amazonaws.com/123456789012/",
+                "--sqs_input_queue",
+                "mock-input-queue",
+                "--sqs_output_queue",
+                "mock-output-queue",
+                "--collection_handle",
+                "123.4/5678",
+            ],
         )
+        assert result.exit_code == 0
         assert "A PDF could not be retrieved for DOI: 10.1002/none.0000" in caplog.text
         assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
-        assert response == "Submission process has completed"
+        assert "Submission process has completed" in caplog.text
 
 
-def test_deposit_s3_upload_failed(caplog, web_mock, s3_mock, s3_class):
-    with caplog.at_level(logging.INFO):
-        response = deposit.deposit(
-            "tests/fixtures/doi_success.csv",
-            "http://example.com/works/",
-            "http://example.com/doi/",
-            "not-a-bucket",
-            "https://queue.amazonaws.com/123456789012/",
-            "mock-input-queue",
-            "mock-output-queue",
-            "123.4/5678",
+def test_deposit_s3_upload_failed(caplog, web_mock, s3_mock, s3_class, runner):
+    with caplog.at_level(logging.DEBUG):
+        result = runner.invoke(
+            deposit,
+            [
+                "--doi_spreadsheet_path",
+                "tests/fixtures/doi_success.csv",
+                "--metadata_url",
+                "http://example.com/works/",
+                "--content_url",
+                "http://example.com/doi/",
+                "--bucket",
+                "not-a-bucket",
+                "--sqs_base_url",
+                "https://queue.amazonaws.com/123456789012/",
+                "--sqs_input_queue",
+                "mock-input-queue",
+                "--sqs_output_queue",
+                "mock-output-queue",
+                "--collection_handle",
+                "123.4/5678",
+            ],
         )
-    assert "Upload failed: 10.1002-term.3131.json" in caplog.text
-    assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
-    assert response == "Submission process has completed"
+        assert result.exit_code == 0
+        assert "Upload failed: 10.1002-term.3131.json" in caplog.text
+        assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
+        assert "Submission process has completed" in caplog.text


### PR DESCRIPTION
#### What does this PR do?
* Add click to `deposit` and `listen` functions for easier operation
* Add commands to Pipfile so `deposit` and `listen` functions can be called
* Update tests to properly test functions as click commands

#### Helpful background context
Using click will make it easier to use a planned a config file that uses SSM Parameter Store or environmental variables for most, if not all, of the values needed for the operation of the `deposit` and `listen` functions.

#### How can a reviewer manually see the effects of these changes?
Ensure that the unit tests still pass when running `pipenv run pytest`

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES