### PR TITLE
DLSPP-118

### DIFF
--- a/awd/listen.py
+++ b/awd/listen.py
@@ -1,12 +1,21 @@
+import io
 import logging
+from datetime import datetime
 
 import click
 from botocore.exceptions import ClientError
 
+from awd.ses import SES
 from awd.sqs import SQS
 
+stream = io.StringIO()
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    handlers=[logging.StreamHandler(), logging.StreamHandler(stream)],
+)
+logging.getLogger("botocore").setLevel(logging.ERROR)
 
 
 @click.command()
@@ -20,21 +29,53 @@ logging.basicConfig(level=logging.INFO)
     required=True,
     help="The SQS queue from which results messages will be received.",
 )
-def listen(sqs_base_url, sqs_output_queue):
+@click.option(
+    "--log_source_email",
+    required=True,
+    help="The email address sending the logs.",
+)
+@click.option(
+    "--log_recipient_email",
+    required=True,
+    multiple=True,
+    help="The email address receiving the logs. Repeatable",
+)
+def listen(sqs_base_url, sqs_output_queue, log_source_email, log_recipient_email):
+    date = datetime.today().strftime("%m-%d-%Y %H:%M:%S")
     sqs = SQS()
     try:
         for message in sqs.receive(sqs_base_url, sqs_output_queue):
+            doi = (
+                message.get("MessageAttributes", {})
+                .get("PackageID", {})
+                .get("StringValue")
+            )
             if "'ResultType': 'error'" in message["Body"]:
-                logger.error(message["Body"])
+                logger.error(f'DOI: {doi}, Result: {message.get("Body")}')
                 sqs.delete(sqs_base_url, sqs_output_queue, message["ReceiptHandle"])
             else:
-                logger.info(message["Body"])
+                logger.info(f'DOI: {doi}, Result: {message.get("Body")}')
                 sqs.delete(sqs_base_url, sqs_output_queue, message["ReceiptHandle"])
         logger.debug("Messages received and deleted from output queue")
     except ClientError as e:
         logger.error(
             f"Failure while retrieving SQS messages, {e.response['Error']['Message']}"
         )
+    ses_client = SES()
+    message = ses_client.create_email(
+        f"DSS results {date}",
+        stream.getvalue(),
+        f"DSS results {date}.txt",
+    )
+    try:
+        ses_client.send_email(
+            log_source_email,
+            list(log_recipient_email),
+            message,
+        )
+        logger.info(f"Logs sent to {list(log_recipient_email)}")
+    except ClientError as e:
+        logger.error(f"Failed to send logs: {e.response['Error']['Message']}")
 
 
 if __name__ == "__main__":

--- a/awd/ses.py
+++ b/awd/ses.py
@@ -1,0 +1,38 @@
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+
+from boto3 import client
+
+
+class SES:
+    """An SES class that provides a generic boto3 SES client."""
+
+    def __init__(self):
+        self.client = client("ses", region_name="us-east-1")
+
+    def create_email(
+        self,
+        subject,
+        attachment_content,
+        attachment_name,
+    ):
+        """Create an email."""
+        message = MIMEMultipart()
+        message["Subject"] = subject
+        attachment_object = MIMEApplication(attachment_content)
+        attachment_object.add_header(
+            "Content-Disposition", "attachment", filename=attachment_name
+        )
+        message.attach(attachment_object)
+        return message
+
+    def send_email(self, source_email, recipients, message):
+        """Send email via SES. Recipients parameter must be a list and not a str."""
+        response = self.client.send_raw_email(
+            Source=source_email,
+            Destinations=recipients,
+            RawMessage={
+                "Data": message.as_string(),
+            },
+        )
+        return response

--- a/awd/sqs.py
+++ b/awd/sqs.py
@@ -42,7 +42,9 @@ class SQS:
         logger.debug(f"Receiving messages from SQS queue: {queue}")
         while True:
             response = self.client.receive_message(
-                QueueUrl=f"{sqs_base_url}{queue}", MaxNumberOfMessages=10
+                QueueUrl=f"{sqs_base_url}{queue}",
+                MaxNumberOfMessages=10,
+                MessageAttributeNames=["All"],
             )
             if "Messages" in response:
                 for message in response["Messages"]:

--- a/config/metadata_mapping.json
+++ b/config/metadata_mapping.json
@@ -4,7 +4,7 @@
   "ISSN": "dc.identifier.issn",
   "issue": "mit.journal.issue",
   "issued": "dc.date.issued",
-  "language": "dc.langauge",
+  "language": "dc.language",
   "original-title": "dc.title.alternative",
   "publisher": "dc.publisher",
   "short-title": "dc.title.alternative",

--- a/tests/fixtures/dspace_metadata.json
+++ b/tests/fixtures/dspace_metadata.json
@@ -1,5 +1,6 @@
 {
-  "metadata": [{
+  "metadata": [
+    {
       "key": "dc.contributor.author",
       "value": "Eivazzadeh‐Keihan, Reza"
     },
@@ -68,7 +69,7 @@
       "value": "2020-09-30"
     },
     {
-      "key": "dc.langauge",
+      "key": "dc.language",
       "value": "en"
     },
     {

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,0 +1,29 @@
+from email.mime.multipart import MIMEMultipart
+
+import boto3
+from moto import mock_ses
+
+from awd import ses
+
+
+def test_ses_create_email():
+    message = ses.SES().create_email(
+        "Email subject",
+        "<html/>",
+        "attachment",
+    )
+    assert message["Subject"] == "Email subject"
+    assert message.get_payload()[0].get_filename() == "attachment"
+
+
+@mock_ses
+def test_ses_send_email():
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    message = message = MIMEMultipart()
+    response = ses.SES().send_email(
+        "noreply@example.com",
+        ["test@example.com"],
+        message,
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -15,7 +15,7 @@ def test_sqs_delete_success(
     sqs_class.send(
         "https://queue.amazonaws.com/123456789012/",
         "mock-output-queue",
-        {},
+        result_message_attributes,
         result_success_message_body,
     )
     messages = sqs_class.receive(
@@ -45,7 +45,7 @@ def test_sqs_receive_success(
     sqs_class.send(
         "https://queue.amazonaws.com/123456789012/",
         "mock-output-queue",
-        {},
+        result_message_attributes,
         result_success_message_body,
     )
     messages = sqs_class.receive(
@@ -53,6 +53,7 @@ def test_sqs_receive_success(
     )
     for message in messages:
         assert message["Body"] == str(result_success_message_body)
+        assert message["MessageAttributes"] == result_message_attributes
 
 
 @mock_sqs


### PR DESCRIPTION
#### What does this PR do?
This is a series of commits enables log messages to be sent to stakeholders. 

The first commit corrects a spelling mistake that caused errors when posting to DSpace.

The second commit creates a SES class with basic functionality for sending email messages with attachments (largely unmodified from the code begin run in production for `alma-scripts`)

The third commit add the necessary click options to `deposit` and `listen` and calls the SES functions to send emails to stakeholders.

#### Helpful background context
I confirmed with Sadie that she wants to receive a full report from the DSS stage of the process rather than just the error which explains the differing logging behavior between `deposit` and `listen`. She also specified the need for a DOI in all error message so the SQS `receive` method was updated to also retrieve message attributes in addition to the message body.

#### How can a reviewer manually see the effects of these changes?
Run the unit tests with `pipenv run pytest`

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DLSPP-118

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
