### PR TITLE
Create infrastructure permissions tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,28 @@
+SHELL=/bin/bash
+DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
+ECR_REGISTRY=672626379771.dkr.ecr.us-east-1.amazonaws.com
+
+dist: ## Build docker container
+	docker build --platform linux/amd64 -t $(ECR_REGISTRY)/wiley-deposits-stage:latest \
+		-t $(ECR_REGISTRY)/wiley-deposits-stage:`git describe --always` \
+		-t awd:latest .	
+
+publish: dist ## Build, tag and push
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY)
+	docker push $(ECR_REGISTRY)/wiley-deposits-stage:latest
+	docker push $(ECR_REGISTRY)/wiley-deposits-stage:`git describe --always`
+
+promote: ## Promote the current staging build to production
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY)
+	docker pull $(ECR_REGISTRY)/wiley-deposits-stage:latest
+	docker tag $(ECR_REGISTRY)/wiley-deposits-stage:latest $(ECR_REGISTRY)/wiley-deposits-prod:latest
+	docker tag $(ECR_REGISTRY)/wiley-deposits-stage:latest $(ECR_REGISTRY)/wiley-deposits-prod:$(DATETIME)
+	docker push $(ECR_REGISTRY)/wiley-deposits-prod:latest
+	docker push $(ECR_REGISTRY)/wiley-deposits-prod:$(DATETIME)
+
+check-permissions-stage: ## Check infrastructure permissions on the staging deplpyment
+	aws ecs run-task --cluster wiley-stage --task-definition wiley-stage --network-configuration "awsvpcConfiguration={subnets=[subnet-0b860205e2831b8d0,subnet-039b5e11cd30385c3],securityGroups=[sg-0dbcd7c12a35e44a0],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1 --overrides '{"containerOverrides": [{"name": "wiley","command": ["check-permissions"]}]}'
+
 lint: bandit black flake8 isort
 
 bandit:

--- a/awd/cli.py
+++ b/awd/cli.py
@@ -319,7 +319,6 @@ def check_permissions():
         happen and the test message will remain in the queue. It is best to only run
         this command when the configured output queues are empty.
     """
-
     dynamodb = DynamoDB()
     logger.info(dynamodb.check_read_permissions(config.DOI_TABLE))
     logger.info(dynamodb.check_write_permissions(config.DOI_TABLE))
@@ -335,7 +334,11 @@ def check_permissions():
         logger.info(ssm.check_permissions(path))
 
     sqs = SQS()
-    logger.info(sqs.check_write_permissions(config.SQS_BASE_URL, config.SQS_INPUT_QUEUE))
-    logger.info(sqs.check_read_permissions(config.SQS_BASE_URL, config.SQS_OUTPUT_QUEUE))
+    logger.info(
+        sqs.check_write_permissions(config.SQS_BASE_URL, config.SQS_INPUT_QUEUE)
+    )
+    logger.info(
+        sqs.check_read_permissions(config.SQS_BASE_URL, config.SQS_OUTPUT_QUEUE)
+    )
 
     logger.info(f"All permissions confirmed for env: {config.ENV}")

--- a/awd/cli.py
+++ b/awd/cli.py
@@ -8,8 +8,10 @@ from botocore.exceptions import ClientError
 
 from awd import config, crossref, dynamodb, s3, ses, sqs, wiley
 from awd.dynamodb import DynamoDB
+from awd.s3 import S3
 from awd.ses import SES
 from awd.sqs import SQS
+from awd.ssm import SSM
 from awd.status import Status
 
 logger = logging.getLogger(__name__)
@@ -301,3 +303,39 @@ def listen(
         logger.debug(f"Logs sent to {ctx.obj['log_recipient_email']}")
     except ClientError as e:
         logger.error(f"Failed to send logs: {e.response['Error']['Message']}")
+
+
+@cli.command()
+def check_permissions():
+    """Confirm AWD infrastructure has deployed properly with correct permissions to all
+    expected resources given the current env configuration.
+
+    Note: Only useful in stage and prod envs, as this command requires SSM access which
+        does not get configured in dev.
+
+    Note: Checking SQS write permissions does write a message to each configured output
+        queue. The test message gets deleted as part of the process, however if there
+        are already more than 10 messages in the output queue that delete may not
+        happen and the test message will remain in the queue. It is best to only run
+        this command when the configured output queues are empty.
+    """
+
+    dynamodb = DynamoDB()
+    logger.info(dynamodb.check_read_permissions(config.DOI_TABLE))
+    logger.info(dynamodb.check_write_permissions(config.DOI_TABLE))
+
+    s3 = S3()
+    logger.info(s3.check_permissions(config.BUCKET))
+
+    ses = SES()
+    logger.info(ses.check_permissions(config.LOG_SOURCE_EMAIL, "mock@mock.mock"))
+
+    ssm = SSM()
+    for path in [config.DSS_SSM_PATH, config.WILEY_SSM_PATH]:
+        logger.info(ssm.check_permissions(path))
+
+    sqs = SQS()
+    logger.info(sqs.check_write_permissions(config.SQS_INPUT_QUEUE))
+    logger.info(sqs.check_read_permissions(config.SQS_OUTPUT_QUEUE))
+
+    logger.info(f"All permissions confirmed for env: {config.ENV}")

--- a/awd/cli.py
+++ b/awd/cli.py
@@ -335,7 +335,7 @@ def check_permissions():
         logger.info(ssm.check_permissions(path))
 
     sqs = SQS()
-    logger.info(sqs.check_write_permissions(config.SQS_INPUT_QUEUE))
-    logger.info(sqs.check_read_permissions(config.SQS_OUTPUT_QUEUE))
+    logger.info(sqs.check_write_permissions(config.SQS_BASE_URL, config.SQS_INPUT_QUEUE))
+    logger.info(sqs.check_read_permissions(config.SQS_BASE_URL, config.SQS_OUTPUT_QUEUE))
 
     logger.info(f"All permissions confirmed for env: {config.ENV}")

--- a/awd/config.py
+++ b/awd/config.py
@@ -4,8 +4,8 @@ import os
 from awd.ssm import SSM
 
 ENV = os.getenv("WORKSPACE")
-DSS_SSM_PATH = f'{os.getenv("DSS_SSM_PATH")}{ENV}/'
-WILEY_SSM_PATH = f'{os.getenv("WILEY_SSM_PATH")}{ENV}/'
+DSS_SSM_PATH = f'{os.getenv("DSS_SSM_PATH")}'
+WILEY_SSM_PATH = f'{os.getenv("WILEY_SSM_PATH")}'
 
 logger = logging.getLogger(__name__)
 logger.debug("Configuring awd for current env: %s", ENV)

--- a/awd/config.py
+++ b/awd/config.py
@@ -4,8 +4,8 @@ import os
 from awd.ssm import SSM
 
 ENV = os.getenv("WORKSPACE")
-DSS_SSM_PATH = os.getenv("DSS_SSM_PATH")
-WILEY_SSM_PATH = os.getenv("WILEY_SSM_PATH")
+DSS_SSM_PATH = f'{os.getenv("DSS_SSM_PATH")}{ENV}/'
+WILEY_SSM_PATH = f'{os.getenv("WILEY_SSM_PATH")}{ENV}/'
 
 logger = logging.getLogger(__name__)
 logger.debug("Configuring awd for current env: %s", ENV)
@@ -14,27 +14,26 @@ AWS_REGION_NAME = "us-east-1"
 
 if ENV == "stage" or ENV == "prod":
     ssm = SSM()
-    DOI_FILE_PATH = ssm.get_parameter_value(f"{WILEY_SSM_PATH}{ENV}/doi_file_path")
-    DOI_TABLE = ssm.get_parameter_value(f"{WILEY_SSM_PATH}{ENV}/dynamodb_table_name")
-    METADATA_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}{ENV}/wiley_metadata_url")
-    CONTENT_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}{ENV}/wiley_content_url")
-    BUCKET = ssm.get_parameter_value(f"{WILEY_SSM_PATH}{ENV}/wiley_submit_s3_bucket")
-    SQS_BASE_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}{ENV}/SQS_base_url")
-    SQS_INPUT_QUEUE = ssm.get_parameter_value(f"{DSS_SSM_PATH}{ENV}/dss_input_queue")
+    DOI_FILE_PATH = ssm.get_parameter_value(f"{WILEY_SSM_PATH}doi_file_path")
+
+    DOI_TABLE = ssm.get_parameter_value(f"{WILEY_SSM_PATH}dynamodb_table_name")
+    METADATA_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}wiley_metadata_url")
+    CONTENT_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}wiley_content_url")
+    BUCKET = ssm.get_parameter_value(f"{WILEY_SSM_PATH}wiley_submit_s3_bucket")
+    SQS_BASE_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}SQS_base_url")
+    SQS_INPUT_QUEUE = ssm.get_parameter_value(f"{DSS_SSM_PATH}dss_input_queue")
     SQS_OUTPUT_QUEUE = ssm.get_parameter_value(
-        f"{DSS_SSM_PATH}{ENV}/dss_output_queues"
+        f"{DSS_SSM_PATH}dss_output_queues"
     ).split(",")[1]
 
     COLLECTION_HANDLE = ssm.get_parameter_value(
-        f"{WILEY_SSM_PATH}{ENV}/wiley_collection_handle"
+        f"{WILEY_SSM_PATH}wiley_collection_handle"
     )
-    LOG_SOURCE_EMAIL = ssm.get_parameter_value(
-        f"{WILEY_SSM_PATH}{ENV}/log_source_email"
-    )
+    LOG_SOURCE_EMAIL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}log_source_email")
     LOG_RECIPIENT_EMAIL = ssm.get_parameter_value(
-        f"{WILEY_SSM_PATH}{ENV}/log_recipient_email"
+        f"{WILEY_SSM_PATH}log_recipient_email"
     )
-    RETRY_THRESHOLD = ssm.get_parameter_value(f"{WILEY_SSM_PATH}{ENV}/retry_threshold")
+    RETRY_THRESHOLD = ssm.get_parameter_value(f"{WILEY_SSM_PATH}retry_threshold")
 elif ENV == "test":
     DOI_FILE_PATH = "tests/fixtures/doi_success.csv"
     DOI_TABLE = "test_dois"
@@ -46,7 +45,7 @@ elif ENV == "test":
     SQS_OUTPUT_QUEUE = "mock-output-queue"
     COLLECTION_HANDLE = "123.4/5678"
     LOG_SOURCE_EMAIL = "noreply@example.com"
-    LOG_RECIPIENT_EMAIL = ["mock@mock.mock"]
+    LOG_RECIPIENT_EMAIL = "mock@mock.mock"
     RETRY_THRESHOLD = "10"
 else:
     DOI_FILE_PATH = os.getenv("DOI_FILE_PATH")

--- a/awd/dynamodb.py
+++ b/awd/dynamodb.py
@@ -29,6 +29,31 @@ class DynamoDB:
         )
         return response
 
+    def check_read_permissions(self, doi_table):
+        """Verify that the contents of the specified table can be read."""
+        self.client.scan(
+            TableName=doi_table,
+        )
+        logger.debug(f"Able to access table: {doi_table}")
+        return f"Read permissions confirmed for table: {doi_table}"
+
+    def check_write_permissions(self, doi_table):
+        """Verify that items can be written to the specified table."""
+        self.add_doi_item_to_database(doi_table, "SmokeTest")
+        if "Item" in self.client.get_item(
+            TableName=doi_table,
+            Key={"doi": {"S": "SmokeTest"}},
+        ):
+            logger.debug(f"Test item successfully written to table: {doi_table}")
+        else:
+            logger.error(f"Unable to write item to table: {doi_table}")
+        self.client.delete_item(
+            TableName=doi_table,
+            Key={"doi": {"S": "SmokeTest"}},
+        )
+        logger.debug(f"Test item deleted from table: {doi_table}")
+        return f"Write permissions confirmed for table: {doi_table}"
+
     def retrieve_doi_items_from_database(self, doi_table):
         """Retrieve all DOI items from database table."""
         response = self.client.scan(

--- a/awd/s3.py
+++ b/awd/s3.py
@@ -12,6 +12,23 @@ class S3:
     def __init__(self):
         self.client = client("s3")
 
+    def check_permissions(self, bucket):
+        """Checks S3 ListObjectV2 and GetObject permissions for a bucket. If either
+        command is not allowed for any of the provided buckets, raises an Access
+        Denied bocotore client error.
+        """
+        response = self.client.list_objects_v2(Bucket=bucket, MaxKeys=1)
+        logger.debug(f"Successfully listed objects in bucket '{bucket}'")
+        for object in response["Contents"]:
+            self.client.get_object(Bucket=bucket, Key=object["Key"])
+            logger.debug(
+                f"Successfully retrieved object '{object['Key']}' from bucket "
+                f"'{bucket}'"
+            )
+        return (
+            f"S3 list objects and get object permissions confirmed for bucket: {bucket}"
+        )
+
     def put_file(self, file, bucket, key):
         """Put a file in a specified S3 bucket with a specified key."""
         response = self.client.put_object(

--- a/awd/ses.py
+++ b/awd/ses.py
@@ -1,7 +1,10 @@
+import logging
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 
 from boto3 import client
+
+logger = logging.getLogger(__name__)
 
 
 class SES:
@@ -9,6 +12,14 @@ class SES:
 
     def __init__(self):
         self.client = client("ses", region_name="us-east-1")
+
+    def check_permissions(self, source_email_address, recipient_email_address):
+        """Verify that an email can be sent from the specified email address"""
+        self.send_email(source_email_address, recipient_email_address, MIMEMultipart())
+        logger.debug(f"Email sent from: {source_email_address}")
+        return (
+            f"SES send from permissions confirmed for address: {source_email_address}"
+        )
 
     def create_email(
         self,
@@ -26,11 +37,11 @@ class SES:
         message.attach(attachment_object)
         return message
 
-    def send_email(self, source_email, recipient, message):
+    def send_email(self, source_email, recipient_email_address, message):
         """Send email via SES."""
         response = self.client.send_raw_email(
             Source=source_email,
-            Destinations=[recipient],
+            Destinations=[recipient_email_address],
             RawMessage={
                 "Data": message.as_string(),
             },

--- a/awd/sqs.py
+++ b/awd/sqs.py
@@ -12,21 +12,64 @@ class SQS:
     def __init__(self):
         self.client = client("sqs", region_name="us-east-1")
 
-    def delete(self, sqs_base_url, queue, receipt_handle):
+    def check_read_permissions(self, sqs_base_url, queue_name):
+        """Verify that messages can be received from the specified queue."""
+        self.client.receive_message(
+            QueueUrl=f"{sqs_base_url}{queue_name}",
+            MaxNumberOfMessages=10,
+            MessageAttributeNames=["All"],
+        )
+        logger.debug(f"Able to access queue: {queue_name}")
+        return f"SQS read permissions confirmed for queue: {queue_name}"
+
+    def check_write_permissions(self, sqs_base_url, queue_name):
+        """Verify that messages can be written to the specified queue. During
+        this test, a message is written and deleted from the queue."""
+        response = self.send(
+            sqs_base_url,
+            queue_name,
+            {"PackageID": {"DataType": "String", "StringValue": "SmokeTest"}},
+            {"TestBody": "Testing write permissions"},
+        )
+        message_id = response["MessageId"]
+        if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+            logger.debug(
+                f"Test message successfully written to queue '{queue_name}' with message "
+                f"ID '{message_id}'"
+            )
+        else:
+            logger.error(
+                f"Unable to verify that message with ID '{message_id}' was "
+                f"successfully written to queue: {queue_name}"
+            )
+        messages = self.receive(
+            sqs_base_url,
+            queue_name,
+        )
+        for message in messages:
+            if message["MessageId"] == message_id:
+                self.delete(sqs_base_url, queue_name, message["ReceiptHandle"])
+                logger.debug(
+                    f"Test message with ID '{message_id}' deleted from queue: "
+                    "{queue_name}"
+                )
+        return f"SQS write permissions confirmed for queue: {queue_name}"
+
+    def delete(self, sqs_base_url, queue_name, receipt_handle):
         """Delete message from SQS queue."""
-        logger.debug(f"Deleting {receipt_handle} from SQS queue: {queue}")
+        logger.debug(f"Deleting {receipt_handle} from SQS queue: {queue_name}")
         response = self.client.delete_message(
-            QueueUrl=f"{sqs_base_url}{queue}",
+            QueueUrl=f"{sqs_base_url}{queue_name}",
             ReceiptHandle=receipt_handle,
         )
         logger.debug(f"Message deleted from SQS queue: {response}")
         return response
 
-    def send(self, sqs_base_url, queue, message_attributes, message_body):
+    def send(self, sqs_base_url, queue_name, message_attributes, message_body):
         """Send message via SQS."""
-        logger.debug(f"Sending message to SQS queue: {queue}")
+        logger.debug(f"Sending message to SQS queue: {queue_name}")
         response = self.client.send_message(
-            QueueUrl=f"{sqs_base_url}{queue}",
+            QueueUrl=f"{sqs_base_url}{queue_name}",
             MessageAttributes=message_attributes,
             MessageBody=str(message_body),
         )
@@ -36,22 +79,24 @@ class SQS:
     def receive(
         self,
         sqs_base_url,
-        queue,
+        queue_name,
     ):
         """Receive message via SQS."""
-        logger.debug(f"Receiving messages from SQS queue: {queue}")
+        logger.debug(f"Receiving messages from SQS queue: {queue_name}")
         while True:
             response = self.client.receive_message(
-                QueueUrl=f"{sqs_base_url}{queue}",
+                QueueUrl=f"{sqs_base_url}{queue_name}",
                 MaxNumberOfMessages=10,
                 MessageAttributeNames=["All"],
             )
             if "Messages" in response:
                 for message in response["Messages"]:
-                    logger.debug(f"Message retrieved from SQS queue {queue}: {message}")
+                    logger.debug(
+                        f"Message retrieved from SQS queue {queue_name}: {message}"
+                    )
                     yield message
             else:
-                logger.debug(f"No more messages from SQS queue {queue}")
+                logger.debug(f"No more messages from SQS queue: {queue_name}")
                 break
 
 

--- a/awd/ssm.py
+++ b/awd/ssm.py
@@ -11,6 +11,19 @@ class SSM:
     def __init__(self):
         self.client = client("ssm", region_name="us-east-1")
 
+    def check_permissions(self, ssm_path):
+        """Check whether we can retrieve an encrypted ssm parameter.
+        Raises an exception if we can't retrieve the parameter at all OR if the
+        parameter is retrieved but the value can't be decrypted.
+        """
+        decrypted_parameter = self.get_parameter_value(ssm_path + "secure")
+        if decrypted_parameter != "true":
+            raise Exception(
+                "Was not able to successfully retrieve encrypted SSM parameter "
+                f"{decrypted_parameter}"
+            )
+        return f"SSM permissions confirmed for path '{ssm_path}'"
+
     def get_parameter_value(self, parameter_key):
         """Get parameter value based on the specified key."""
         parameter_object = self.client.get_parameter(

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1,12 +1,5 @@
-# import os
-
-# import boto3
-# import pytest
-# from botocore.exceptions import ClientError
-# from moto.core import set_initial_no_auth_action_count
 from moto import mock_dynamodb2
 
-# from awd.dynamodb import DynamoDB
 from awd.status import Status
 
 
@@ -44,39 +37,6 @@ def test_check_read_permissions_success(
     assert result == "Read permissions confirmed for table: test_dois"
 
 
-# While this function works as expected against stage AWS, the type of errors
-# triggered by the moto mocks of other AWS services do not seem to be triggered
-# for the moto mock of DynamoDB. Leaving this commented out for potential future
-# reference.
-#
-# @mock_dynamodb2
-# @set_initial_no_auth_action_count(2)
-# def test_check_read_permissions_raises_error_if_no_permission(test_aws_user):
-#     dynamodb_client = boto3.client(
-#         "dynamodb",
-#         region_name="us-east-1",
-#     )
-#     dynamodb_client.create_table(
-#         TableName="test_dois",
-#         KeySchema=[
-#             {"AttributeName": "doi", "KeyType": "HASH"},
-#         ],
-#         AttributeDefinitions=[
-#             {"AttributeName": "doi", "AttributeType": "S"},
-#         ],
-#     )
-#     os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
-#     os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
-#     boto3.setup_default_session()
-#     dynamodb_class = DynamoDB()
-#     with pytest.raises(ClientError) as e:
-#         dynamodb_class.check_read_permissions("test_dois")
-#     assert (
-#         "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: "
-#         "dynamodb:Scan"
-#     ) in str(e.value)
-
-
 @mock_dynamodb2
 def test_check_write_permissions_success(dynamodb_class):
     dynamodb_class.client.create_table(
@@ -97,39 +57,6 @@ def test_check_write_permissions_success(dynamodb_class):
             Key={"doi": {"S": "SmokeTest"}},
         )
     )
-
-
-# While this function works as expected against stage AWS, the type of errors
-# triggered by the moto mocks of other AWS services do not seem to be triggered
-# for the moto mock of DynamoDB. Leaving this commented out for potential future
-# reference.
-#
-# @mock_dynamodb2
-# @set_initial_no_auth_action_count(2)
-# def test_check_write_permissions_raises_error_if_no_permission(test_aws_user):
-#     dynamodb_client = boto3.client(
-#         "dynamodb",
-#         region_name="us-east-1",
-#     )
-#     dynamodb_client.create_table(
-#         TableName="test_dois",
-#         KeySchema=[
-#             {"AttributeName": "doi", "KeyType": "HASH"},
-#         ],
-#         AttributeDefinitions=[
-#             {"AttributeName": "doi", "AttributeType": "S"},
-#         ],
-#     )
-#     os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
-#     os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
-#     boto3.setup_default_session()
-#     dynamodb_class = DynamoDB()
-#     with pytest.raises(ClientError) as e:
-#         dynamodb_class.check_write_permissions("test_dois")
-#     assert (
-#         "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: "
-#         "dynamodb:PutItem"
-#     ) in str(e.value)
 
 
 @mock_dynamodb2

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1,5 +1,12 @@
+# import os
+
+# import boto3
+# import pytest
+# from botocore.exceptions import ClientError
+# from moto.core import set_initial_no_auth_action_count
 from moto import mock_dynamodb2
 
+# from awd.dynamodb import DynamoDB
 from awd.status import Status
 
 
@@ -17,6 +24,112 @@ def test_dynamodb_add_doi_item_to_database(dynamodb_class):
     dynamodb_class.client.describe_table(TableName="test_dois")
     add_response = dynamodb_class.add_doi_item_to_database("test_dois", "222.2/2222")
     assert add_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+@mock_dynamodb2
+def test_check_read_permissions_success(
+    dynamodb_class,
+):
+    dynamodb_class.client.create_table(
+        TableName="test_dois",
+        KeySchema=[
+            {"AttributeName": "doi", "KeyType": "HASH"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "doi", "AttributeType": "S"},
+        ],
+    )
+    dynamodb_class.client.describe_table(TableName="test_dois")
+    result = dynamodb_class.check_read_permissions("test_dois")
+    assert result == "Read permissions confirmed for table: test_dois"
+
+
+# While this function works as expected against stage AWS, the type of errors
+# triggered by the moto mocks of other AWS services do not seem to be triggered
+# for the moto mock of DynamoDB. Leaving this commented out for potential future
+# reference.
+#
+# @mock_dynamodb2
+# @set_initial_no_auth_action_count(2)
+# def test_check_read_permissions_raises_error_if_no_permission(test_aws_user):
+#     dynamodb_client = boto3.client(
+#         "dynamodb",
+#         region_name="us-east-1",
+#     )
+#     dynamodb_client.create_table(
+#         TableName="test_dois",
+#         KeySchema=[
+#             {"AttributeName": "doi", "KeyType": "HASH"},
+#         ],
+#         AttributeDefinitions=[
+#             {"AttributeName": "doi", "AttributeType": "S"},
+#         ],
+#     )
+#     os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
+#     os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
+#     boto3.setup_default_session()
+#     dynamodb_class = DynamoDB()
+#     with pytest.raises(ClientError) as e:
+#         dynamodb_class.check_read_permissions("test_dois")
+#     assert (
+#         "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: "
+#         "dynamodb:Scan"
+#     ) in str(e.value)
+
+
+@mock_dynamodb2
+def test_check_write_permissions_success(dynamodb_class):
+    dynamodb_class.client.create_table(
+        TableName="test_dois",
+        KeySchema=[
+            {"AttributeName": "doi", "KeyType": "HASH"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "doi", "AttributeType": "S"},
+        ],
+    )
+    result = dynamodb_class.check_write_permissions("test_dois")
+
+    assert result == "Write permissions confirmed for table: test_dois"
+    assert "Item" not in (
+        dynamodb_class.client.get_item(
+            TableName="test_dois",
+            Key={"doi": {"S": "SmokeTest"}},
+        )
+    )
+
+
+# While this function works as expected against stage AWS, the type of errors
+# triggered by the moto mocks of other AWS services do not seem to be triggered
+# for the moto mock of DynamoDB. Leaving this commented out for potential future
+# reference.
+#
+# @mock_dynamodb2
+# @set_initial_no_auth_action_count(2)
+# def test_check_write_permissions_raises_error_if_no_permission(test_aws_user):
+#     dynamodb_client = boto3.client(
+#         "dynamodb",
+#         region_name="us-east-1",
+#     )
+#     dynamodb_client.create_table(
+#         TableName="test_dois",
+#         KeySchema=[
+#             {"AttributeName": "doi", "KeyType": "HASH"},
+#         ],
+#         AttributeDefinitions=[
+#             {"AttributeName": "doi", "AttributeType": "S"},
+#         ],
+#     )
+#     os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
+#     os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
+#     boto3.setup_default_session()
+#     dynamodb_class = DynamoDB()
+#     with pytest.raises(ClientError) as e:
+#         dynamodb_class.check_write_permissions("test_dois")
+#     assert (
+#         "User: arn:aws:iam::123456789012:user/test-user is not authorized to perform: "
+#         "dynamodb:PutItem"
+#     ) in str(e.value)
 
 
 @mock_dynamodb2

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,4 +1,44 @@
+import os
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto.core import set_initial_no_auth_action_count
+
 from awd import s3
+
+
+def test_s3_check_permissions_success(s3_mock, s3_class):
+    s3_class.put_file(
+        str({"metadata": {"key": "dc.title", "value": "A Title"}}),
+        "awd",
+        "test.json",
+    )
+    result = s3_class.check_permissions("awd")
+    assert (
+        result == "S3 list objects and get object permissions confirmed for bucket: awd"
+    )
+
+
+@set_initial_no_auth_action_count(1)
+def test_s3_check_permissions_raises_error_if_no_permission(
+    s3_mock, s3_class, test_aws_user
+):
+    s3_class.put_file(
+        str({"metadata": {"key": "dc.title", "value": "A Title"}}),
+        "awd",
+        "test.json",
+    )
+    os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
+    os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
+    boto3.setup_default_session()
+    s3_class = s3.S3()
+    with pytest.raises(ClientError) as e:
+        s3_class.check_permissions("awd")
+    assert (
+        "An error occurred (AccessDenied) when calling the GetObject operation: Access "
+        "Denied" in str(e.value)
+    )
 
 
 def test_s3_put_file(s3_mock, s3_class):

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,13 +1,44 @@
+import os
 from email.mime.multipart import MIMEMultipart
 
 import boto3
+import pytest
+from botocore.exceptions import ClientError
 from moto import mock_ses
+from moto.core import set_initial_no_auth_action_count
 
 from awd import ses
 
 
-def test_ses_create_email():
-    message = ses.SES().create_email(
+@mock_ses
+def test_check_permissions_success(ses_class):
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    result = ses_class.check_permissions("noreply@example.com", "mock@mock.mock")
+    assert (
+        result == "SES send from permissions confirmed for address: noreply@example.com"
+    )
+
+
+@mock_ses
+@set_initial_no_auth_action_count(1)
+def test_check_permissions_raises_error_if_address_not_verified(test_aws_user):
+    ses_client = boto3.client("ses", region_name="us-east-1")
+    ses_client.verify_email_identity(EmailAddress="noreply@example.com")
+    os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
+    os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
+    boto3.setup_default_session()
+    ses_class = ses.SES()
+    with pytest.raises(ClientError) as e:
+        ses_class.check_permissions("noreply@example.com", "mock@mock.mock")
+    assert e.value.response["Error"]["Message"] == (
+        "User: arn:aws:iam::123456789012:user/test-user is not authorized to"
+        " perform: ses:SendRawEmail"
+    )
+
+
+def test_ses_create_email(ses_class):
+    message = ses_class.create_email(
         "Email subject",
         "<html/>",
         "attachment",
@@ -17,11 +48,11 @@ def test_ses_create_email():
 
 
 @mock_ses
-def test_ses_send_email():
+def test_ses_send_email(ses_class):
     ses_client = boto3.client("ses", region_name="us-east-1")
     ses_client.verify_email_identity(EmailAddress="noreply@example.com")
     message = message = MIMEMultipart()
-    response = ses.SES().send_email(
+    response = ses_class.send_email(
         "noreply@example.com",
         "test@example.com",
         message,

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,4 +1,36 @@
+# import os
+
+# import boto3
+# import pytest
+# from botocore.exceptions import ClientError
+# from moto.core import set_initial_no_auth_action_count
+
 from awd.ssm import SSM
+
+
+def test_check_permissions_success(mocked_ssm):
+    ssm = SSM()
+    assert (
+        ssm.check_permissions("/test/example/")
+        == "SSM permissions confirmed for path '/test/example/'"
+    )
+
+
+# Unit test and comment below were copied from
+# https://github.com/MITLibraries/dspace-submission-service
+# Encountered similar error and commenting out test for similar reasons
+#
+# This test raises a weird error that seems like a moto issue. Leaving it here but
+# commented out for now
+# @set_initial_no_auth_action_count(0)
+# def test_check_permissions_raises_error_if_no_permission(mocked_ssm, test_aws_user):
+#     os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
+#     os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
+#     # boto3.setup_default_session()
+#     ssm = SSM()
+#     with pytest.raises(ClientError) as e:
+#         ssm.check_permissions("/test/example/")
+#     assert "Access Denied" in str(e.value)
 
 
 def test_ssm_get_parameter_value(mocked_ssm):

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,10 +1,3 @@
-# import os
-
-# import boto3
-# import pytest
-# from botocore.exceptions import ClientError
-# from moto.core import set_initial_no_auth_action_count
-
 from awd.ssm import SSM
 
 
@@ -14,23 +7,6 @@ def test_check_permissions_success(mocked_ssm):
         ssm.check_permissions("/test/example/")
         == "SSM permissions confirmed for path '/test/example/'"
     )
-
-
-# Unit test and comment below were copied from
-# https://github.com/MITLibraries/dspace-submission-service
-# Encountered similar error and commenting out test for similar reasons
-#
-# This test raises a weird error that seems like a moto issue. Leaving it here but
-# commented out for now
-# @set_initial_no_auth_action_count(0)
-# def test_check_permissions_raises_error_if_no_permission(mocked_ssm, test_aws_user):
-#     os.environ["AWS_ACCESS_KEY_ID"] = test_aws_user["AccessKeyId"]
-#     os.environ["AWS_SECRET_ACCESS_KEY"] = test_aws_user["SecretAccessKey"]
-#     # boto3.setup_default_session()
-#     ssm = SSM()
-#     with pytest.raises(ClientError) as e:
-#         ssm.check_permissions("/test/example/")
-#     assert "Access Denied" in str(e.value)
 
 
 def test_ssm_get_parameter_value(mocked_ssm):


### PR DESCRIPTION
#### What does this PR do?
* Add permissions check methods to `DynamoDB`, `S3`, `SES`, `SQS`, and `SSM` classes
* Add unit tests for new methods
* Add and update fixtures for new unit tests

#### Helpful background context
The `check_permissions` function for the `SES` class sends an email when run against `stage` or `prod`.  @zotoMIT mentioned a way to override sending an email with env vars, we can discuss the details in the PR review. I currently have a mock address as the recipient.

With 3 unit tests designed to verify the correct error reporting when the new methods fail, I was not able to get the desired results, likely due to issues with `moto`'s mocking infrastructure. Since the tests verifying the successful use of the new methods are functioning properly, I chose to comment out the failing tests so they are available for future development and won't delay more important work. 

#### How can a reviewer manually see the effects of these changes?
Run the included unit tests with `pipenv run pytest`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DLSPP-136

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
