### PR TITLE
Add methods to S3 class for selecting and archiving CSVs

### DIFF
--- a/awd/config.py
+++ b/awd/config.py
@@ -14,8 +14,6 @@ AWS_REGION_NAME = "us-east-1"
 
 if ENV == "stage" or ENV == "prod":
     ssm = SSM()
-    DOI_FILE_PATH = ssm.get_parameter_value(f"{WILEY_SSM_PATH}doi_file_path")
-
     DOI_TABLE = ssm.get_parameter_value(f"{WILEY_SSM_PATH}dynamodb_table_name")
     METADATA_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}wiley_metadata_url")
     CONTENT_URL = ssm.get_parameter_value(f"{WILEY_SSM_PATH}wiley_content_url")

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -41,6 +41,49 @@ def test_s3_check_permissions_raises_error_if_no_permission(
     )
 
 
+def test_s3_filter_files_in_bucket_with_matching_csv(s3_mock, s3_class):
+    s3_class.put_file(
+        "test1,test2,test3,test4",
+        "awd",
+        "test.csv",
+    )
+    files = s3_class.filter_files_in_bucket("awd", "csv", "archived")
+    for file in files:
+        assert file == "test.csv"
+
+
+def test_s3_filter_files_in_bucket_without_matching_csv(s3_mock, s3_class):
+    s3_class.put_file(
+        "test1,test2,test3,test4",
+        "awd",
+        "archived/test.csv",
+    )
+    files = s3_class.filter_files_in_bucket("awd", "csv", "archived")
+    for file in files:
+        assert file == "test.csv"
+
+
+def test_archive_file_in_bucket(s3_mock, s3_class):
+    s3_class.put_file(
+        "test1,test2,test3,test4",
+        "awd",
+        "test.csv",
+    )
+    s3_class.archive_file_with_new_key(
+        "awd",
+        "test.csv",
+        "archived",
+    )
+    with pytest.raises(ClientError) as e:
+        response = s3_class.client.get_object(Bucket="awd", Key="test.csv")
+    assert (
+        "An error occurred (NoSuchKey) when calling the GetObject operation: The"
+        " specified key does not exist." in str(e.value)
+    )
+    response = s3_class.client.get_object(Bucket="awd", Key="archived/test.csv")
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
 def test_s3_put_file(s3_mock, s3_class):
     assert "Contents" not in s3_class.client.list_objects(Bucket="awd")
     s3_class.put_file(


### PR DESCRIPTION
#### What does this PR do?
* Add methods to S3 class to select CSVs and archive the files after processing
* Update deposit function with new methods and a bucket check at start
* Remove doi_file_path from config.py and deposit.py
* Update unit tests and fixtures to account for the updated code

#### Helpful background context
The `test_deposit_s3_upload_failed` CLI test was refactored into `test_deposit_s3_nonexistent_bucket` given that access to the bucket should be determined at the start of the process

#### How can a reviewer manually see the effects of these changes?
Ensure the unit tests still pass with `pipenv run pytest`

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/DLSPP-139

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
