### PR TITLE
add makefile and ecr push github action

### DIFF
--- a/.github/workflows/stage_ecr_push.yml
+++ b/.github/workflows/stage_ecr_push.yml
@@ -1,0 +1,20 @@
+# Borrowed heavily from mario
+name: Stage
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy staging build
+    runs-on: ubuntu-latest
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: ${{ secrets.WILEY_DEPLOY_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.WILEY_DEPLOY_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: make dist
+      - name: Push image
+        run: make publish

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ promote: ## Promote the current staging build to production
 check-permissions-stage: ## Check infrastructure permissions on the staging deplpyment
 	aws ecs run-task --cluster wiley-stage --task-definition wiley-stage --network-configuration "awsvpcConfiguration={subnets=[subnet-0b860205e2831b8d0,subnet-039b5e11cd30385c3],securityGroups=[sg-0dbcd7c12a35e44a0],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1 --overrides '{"containerOverrides": [{"name": "wiley","command": ["check-permissions"]}]}'
 
+run-deposit-stage: ## Run the stage-deposit command
+	aws ecs run-task --cluster wiley-stage --task-definition wiley-stage --network-configuration "awsvpcConfiguration={subnets=[subnet-0b860205e2831b8d0,subnet-039b5e11cd30385c3],securityGroups=[sg-0dbcd7c12a35e44a0],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1 --overrides '{"containerOverrides": [{"name": "wiley","command": ["deposit"]}]}'
+
+run-listen-stage: ## Run the stage listen command
+	aws ecs run-task --cluster wiley-stage --task-definition wiley-stage --network-configuration "awsvpcConfiguration={subnets=[subnet-0b860205e2831b8d0,subnet-039b5e11cd30385c3],securityGroups=[sg-0dbcd7c12a35e44a0],assignPublicIp=DISABLED}" --launch-type FARGATE --region us-east-1 --overrides '{"containerOverrides": [{"name": "wiley","command": ["listen"]}]}'
+
 lint: bandit black flake8 isort
 
 bandit:

--- a/awd/dynamodb.py
+++ b/awd/dynamodb.py
@@ -23,7 +23,7 @@ class DynamoDB:
             TableName=doi_table,
             Item={
                 "doi": {"S": doi},
-                "status": {"S": str(Status.PROCESSING)},
+                "status": {"S": str(Status.PROCESSING.value)},
                 "attempts": {"S": "0"},
             },
         )


### PR DESCRIPTION
#### What does this PR do?
This PR adds two additional makefile commands, `run-deposits-stage` and `run-listen-stage`.  
It also adds a github action to compile and deposit the ecr image to the registry automatically on merges to main.  
A correction is also made to the `DynamoDB` class so that the proper numeric code is added to the table when a new item is added.

#### Helpful background context

The makefile commands are copy-pasted from the terraform deploy for wiley.  
The github action is borrowed heavily from DSS.  

#### How can a reviewer manually see the effects of these changes?

I have tested these commands locally, but the action has not been tested here, as it has to be run in github.  

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/DLSPP-131

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
