### PR TITLE
Add dynamodb update

### DIFF
--- a/awd/cli.py
+++ b/awd/cli.py
@@ -286,6 +286,9 @@ def listen(
                         ctx.obj["doi_table"], doi, Status.FAILED.value
                     )
                 else:
+                    dynamodb_client.update_doi_item_status_in_database(
+                        ctx.obj["doi_table"], doi, Status.UNPROCESSED.value
+                    )
                     continue
             else:
                 logger.info(f"DOI: {doi}, Result: {body}")


### PR DESCRIPTION
#### What does this PR do?
* Add dynamodb update call to listen function when second issue was revealed after the previous fix

#### Helpful background context
The status logic was incomplete given the lack of a call to reset an item's status from MESSAGE_SENT to UNPROCESSED if there was a DSS error 

#### How can a reviewer manually see the effects of these changes?
Ensure the unit tests pass with `pipenv run pytest`

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
