### PR TITLE
In 891 add linting ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for application
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "MITLibraries/dataeng"
+
+  # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "MITLibraries/dataeng"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+default_language_version:
+  python: python3.11 # set for project python version
+repos:
+  - repo: local
+    hooks:
+      - id: black-apply
+        name: black-apply
+        entry: pipenv run black
+        language: system
+        pass_filenames: true
+        types: ["python"]
+      - id: mypy
+        name: mypy
+        entry: pipenv run mypy
+        language: system
+        pass_filenames: true
+        types: ["python"]
+      - id: ruff-apply
+        name: ruff-apply
+        entry: pipenv run ruff check --fix
+        language: system
+        pass_filenames: true
+        types: ["python"]
+      - id: safety
+        name: safety
+        entry: pipenv check
+        language: system
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ coveralls: test
 
 
 ### Linting commands ###
-lint: black mypy safety
+lint: black mypy ruff safety 
 
 black:
 	pipenv run black --check --diff .
@@ -78,12 +78,18 @@ black:
 mypy:
 	pipenv run mypy awd
 
+ruff:
+	pipenv run ruff check .
+
 safety:
 	pipenv check
 	pipenv verify
 
 # Apply changes to resolve any linting errors
-lint-apply: black-apply
+lint-apply: black-apply ruff-apply
 
 black-apply: 
 	pipenv run black .
+
+ruff-apply: 
+	pipenv run ruff check --fix .

--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ pytest-cov = "*"
 requests-mock = "*"
 ruff = "*"
 types-requests = "*"
+pre-commit = "*"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:807d4a4698ba9a76d5901a1663ff1943d13efbc388908f38b60f209c3511f1d6",
-                "sha256:839deb868d1278dd5a3f87208cfc4a8e259c95ca3cbe607cc322d435f02f63b0"
+                "sha256:20feedb753e87d6dd55665e2e9dda08b031518291350c9c57b552c86a537fd4e",
+                "sha256:f08f6c83608721c2142abd2ccc5f15bd5c98c282ad9e0d39f9efc59d98604658"
             ],
             "index": "pypi",
-            "version": "==1.28.23"
+            "version": "==1.28.25"
         },
         "boto3-stubs": {
             "extras": [
@@ -30,19 +30,19 @@
                 "ses"
             ],
             "hashes": [
-                "sha256:210012db23c1679464d7630c05a9535ebf0f7d9d2c0aa4dbd9e20fe3a72b4dbf",
-                "sha256:846669f0c43e1f88b466c6b3bdc701272f9c476021b5aef4fd981cfe6f78ce25"
+                "sha256:375ed143ff4af674d923a7a7420e46f6109960bb731133b282a59beec4ad3418",
+                "sha256:5d3c0df26006f98126624a999384a247138d83470c034f0f03cf92435487529f"
             ],
             "index": "pypi",
-            "version": "==1.28.23"
+            "version": "==1.28.24"
         },
         "botocore": {
             "hashes": [
-                "sha256:d0a95f74eb6bd99e8f52f16af0a430ba6cd1526744f40ffdd3fcccceeaf961c2",
-                "sha256:f3258feaebce48f138eb2675168c4d33cc3d99e9f45af13cb8de47bdc2b9c573"
+                "sha256:17cc6db84644251a5b519aeccd5eb1c313a18ef2e92616ec16182aa30c877152",
+                "sha256:b8a40b0ca1e3c8290a4c0d473c8e1575d2e8b2ddc3c61dd8814c3976357cac84"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.23"
+            "version": "==1.31.25"
         },
         "botocore-stubs": {
             "hashes": [
@@ -228,19 +228,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:807d4a4698ba9a76d5901a1663ff1943d13efbc388908f38b60f209c3511f1d6",
-                "sha256:839deb868d1278dd5a3f87208cfc4a8e259c95ca3cbe607cc322d435f02f63b0"
+                "sha256:20feedb753e87d6dd55665e2e9dda08b031518291350c9c57b552c86a537fd4e",
+                "sha256:f08f6c83608721c2142abd2ccc5f15bd5c98c282ad9e0d39f9efc59d98604658"
             ],
             "index": "pypi",
-            "version": "==1.28.23"
+            "version": "==1.28.25"
         },
         "botocore": {
             "hashes": [
-                "sha256:d0a95f74eb6bd99e8f52f16af0a430ba6cd1526744f40ffdd3fcccceeaf961c2",
-                "sha256:f3258feaebce48f138eb2675168c4d33cc3d99e9f45af13cb8de47bdc2b9c573"
+                "sha256:17cc6db84644251a5b519aeccd5eb1c313a18ef2e92616ec16182aa30c877152",
+                "sha256:b8a40b0ca1e3c8290a4c0d473c8e1575d2e8b2ddc3c61dd8814c3976357cac84"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.23"
+            "version": "==1.31.25"
         },
         "certifi": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8b0919ec7916bbab1c9b89ed6ed2bafddea379aeafdb79b7c770bb9b814d91cf"
+            "sha256": "657d5e1ddafeedabb9bac0128c0d538c8c0fdcc7f030fc18da73ae4d8a76fb22"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,11 +30,11 @@
                 "ses"
             ],
             "hashes": [
-                "sha256:375ed143ff4af674d923a7a7420e46f6109960bb731133b282a59beec4ad3418",
-                "sha256:5d3c0df26006f98126624a999384a247138d83470c034f0f03cf92435487529f"
+                "sha256:27847e8cf5d256a8d80b8a94fb60f0269d884aeccad345a9b80eb9c78b85f1a0",
+                "sha256:6a14f7800b73f5f3dfaa7feed70b49ab81fd162c810afb2c5ddaed481dc51b9f"
             ],
             "index": "pypi",
-            "version": "==1.28.24"
+            "version": "==1.28.25"
         },
         "botocore": {
             "hashes": [
@@ -120,10 +120,10 @@
         },
         "mypy-boto3-ses": {
             "hashes": [
-                "sha256:1ee3de51ed145a2b7667d69a967983a5105fbd3e0aa6489e1734bb58cfe0af5a",
-                "sha256:f1869c2e86cb9766bf84acd5e27fd92e3a2921b5feb5a2f72b46a038471244aa"
+                "sha256:169b36ebf1fe38bfa2ca3ba016e72dcbdf027ff0ee16fa888d6548ac58c48940",
+                "sha256:62dbccc990402e3e36af049d0403cdfb15ade18c34f7ec6e140bcb30ec62379d"
             ],
-            "version": "==1.28.16"
+            "version": "==1.28.25"
         },
         "mypy-boto3-sqs": {
             "hashes": [
@@ -319,6 +319,14 @@
             ],
             "version": "==1.15.1"
         },
+        "cfgv": {
+            "hashes": [
+                "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426",
+                "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==3.3.1"
+        },
         "charset-normalizer": {
             "hashes": [
                 "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96",
@@ -501,11 +509,34 @@
             "markers": "python_version >= '3.7'",
             "version": "==41.0.3"
         },
+        "distlib": {
+            "hashes": [
+                "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057",
+                "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"
+            ],
+            "version": "==0.3.7"
+        },
         "docopt": {
             "hashes": [
                 "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
             ],
             "version": "==0.6.2"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81",
+                "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.12.2"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:7243800bce2f58404ed41b7c002e53d4d22bcf3ae1b7900c2d7aefd95394bf7f",
+                "sha256:c22a8ead0d4ca11f1edd6c9418c3220669b3b7533ada0a0ffa6cc0ef85cf9b54"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.5.26"
         },
         "idna": {
             "hashes": [
@@ -639,6 +670,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
         },
+        "nodeenv": {
+            "hashes": [
+                "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2",
+                "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==1.8.0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
@@ -670,6 +709,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.2.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:10badb65d6a38caff29703362271d7dca483d01da88f9d7e05d0b97171c136cb",
+                "sha256:a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023"
+            ],
+            "index": "pypi",
+            "version": "==3.3.3"
         },
         "pycparser": {
             "hashes": [
@@ -803,6 +850,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==0.6.1"
         },
+        "setuptools": {
+            "hashes": [
+                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
+                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==68.0.0"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -848,6 +903,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.26.16"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:95a6e9398b4967fbcb5fef2acec5efaf9aa4972049d9ae41f95e0972a683fd02",
+                "sha256:e5c3b4ce817b0b328af041506a2a299418c98747c4b1e68cb7527e74ced23efc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==20.24.3"
         },
         "werkzeug": {
             "hashes": [

--- a/awd/cli.py
+++ b/awd/cli.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
+import datetime
 import io
 import json
 import logging
-from datetime import datetime
+import sys
 from typing import Any
 
 import click
@@ -20,8 +23,7 @@ logger = logging.getLogger(__name__)
 def create_list_of_dspace_item_files(
     file_name: str, metadata_content: str, bitstream_content: bytes
 ) -> list[tuple[str, str | bytes]]:
-    """Create a list of tuples containing metadata and bitstream file names and
-    file content for a DSpace item."""
+    """Create a list of metadata and content tuples for a DSpace item."""
     return [
         (
             f"{file_name}.json",
@@ -35,24 +37,24 @@ def create_list_of_dspace_item_files(
 
 
 def doi_to_be_added(doi: str, doi_items: list[dict[str, Any]]) -> bool:
-    "Validate that a DOI is not a part of the database table and needs to  be added."
+    """Validate that a DOI is not a part of the database table and needs to  be added."""
     validation_status = False
     if not any(doi_item["doi"] == doi for doi_item in doi_items):
         validation_status = True
-        logger.debug(f"{doi} added to database.")
+        logger.debug("%s added to database", doi)
     return validation_status
 
 
 def doi_to_be_retried(doi: str, doi_items: list[dict[str, Any]]) -> bool:
-    "Validate that a DOI should be retried based on its status in the database table."
+    """Validate that a DOI should be retried based on its status in the database table."""
     validation_status = False
-    for doi_item in [
+    for _doi_item in [
         d
         for d in doi_items
         if d["doi"] == doi and d["status"] == str(Status.UNPROCESSED.value)
     ]:
         validation_status = True
-        logger.debug(f"{doi} will be retried.")
+        logger.debug("%s will be retried", doi)
     return validation_status
 
 
@@ -169,10 +171,11 @@ def deposit(
     sqs_input_queue: str,
     collection_handle: str,
 ) -> None:
-    """Process a text file of DOIs to retrieve and send metadata and PDFs as SQS messages
-    to the DSpace Submission Service. Errors generated during the process are emailed
-    to stakeholders."""
-    date = datetime.today().strftime("%m-%d-%Y %H:%M:%S")
+    """Process a text file of DOIs to retrieve metadata and PDFs and send to SQS queue.
+
+    Errors generated during the process are emailed to stakeholders.
+    """
+    date = datetime.datetime.now(tz=datetime.UTC).strftime(config.DATE_FORMAT)
     stream = ctx.obj["stream"]
     s3_client = s3.S3()
     sqs_client = sqs.SQS(ctx.obj["aws_region"])
@@ -181,10 +184,10 @@ def deposit(
     try:
         s3_client.client.list_objects_v2(Bucket=bucket)
     except ClientError as e:
-        logger.error(
-            f"Error accessing bucket: {bucket}, {e.response['Error']['Message']}"
+        logger.exception(
+            "Error accessing bucket: %s, %s", bucket, e.response["Error"]["Message"]
         )
-        exit
+        sys.exit()
     for doi_file in s3_client.filter_files_in_bucket(bucket, ".csv", "archived"):
         dois = crossref.get_dois_from_spreadsheet(f"s3://{bucket}/{doi_file}")
         try:
@@ -192,15 +195,17 @@ def deposit(
                 ctx.obj["doi_table"]
             )
         except ClientError as e:
-            logger.error(f"Table read failed: {e.response['Error']['Message']}")
-            exit
+            logger.exception("Table read failed: %s", e.response["Error"]["Message"])
+            sys.exit()
         for doi in dois:
             if doi_to_be_added(doi, doi_items):
                 try:
                     dynamodb_client.add_doi_item_to_database(ctx.obj["doi_table"], doi)
                 except ClientError as e:
-                    logger.error(
-                        f"Table error while processing {doi}: {e.response['Error']['Message']}"
+                    logger.exception(
+                        "Table error while processing %s: %s",
+                        doi,
+                        e.response["Error"]["Message"],
                     )
             elif doi_to_be_retried(doi, doi_items) is False:
                 continue
@@ -208,11 +213,13 @@ def deposit(
                 dynamodb_client.update_doi_item_attempts_in_database(
                     ctx.obj["doi_table"], doi
                 )
-            except KeyError as e:
-                logger.error("Key error in table while processing %s: %s", doi, e)
+            except KeyError:
+                logger.exception("Key error in table while processing %s", doi)
             except ClientError as e:
-                logger.error(
-                    f"Table error while processing {doi}: {e.response['Error']['Message']}"
+                logger.exception(
+                    "Table error while processing %s: %s",
+                    doi,
+                    e.response["Error"]["Message"],
                 )
             crossref_work_record = crossref.get_work_record_from_doi(metadata_url, doi)
             if crossref.is_valid_response(doi, crossref_work_record) is False:
@@ -235,8 +242,8 @@ def deposit(
                 ):
                     s3_client.put_file(file_contents, bucket, file_name)
             except ClientError as e:
-                logger.error(
-                    f"Upload failed: {file_name}," f"{e.response['Error']['Message']}"
+                logger.exception(
+                    "Upload failed for  %s: %s", file_name, e.response["Error"]["Message"]
                 )
                 continue
             bitstream_s3_uri = f"s3://{bucket}/{doi_file_name}.pdf"
@@ -261,11 +268,13 @@ def deposit(
                 dynamodb_client.update_doi_item_status_in_database(
                     ctx.obj["doi_table"], doi, Status.MESSAGE_SENT.value
                 )
-            except KeyError as e:
-                logger.error("Key error in table while processing %s: %s", doi, e)
+            except KeyError:
+                logger.exception("Key error in table while processing %s", doi)
             except ClientError as e:
-                logger.error(
-                    f"Table error while processing {doi}: {e.response['Error']['Message']}"
+                logger.exception(
+                    "Table error while processing %s: %s",
+                    doi,
+                    e.response["Error"]["Message"],
                 )
         s3_client.archive_file_with_new_key(bucket, doi_file, "archived")
     logger.debug("Submission process has completed")
@@ -282,9 +291,9 @@ def deposit(
             ctx.obj["log_recipient_email"],
             email_message,
         )
-        logger.debug(f"Logs sent to {ctx.obj['log_recipient_email']}")
+        logger.debug("Logs sent to %s", ctx.obj["log_recipient_email"])
     except ClientError as e:
-        logger.error(f"Failed to send logs: {e.response['Error']['Message']}")
+        logger.exception("Failed to send logs: %s", e.response["Error"]["Message"])
 
 
 @cli.command()
@@ -299,9 +308,8 @@ def listen(
     ctx: click.Context,
     retry_threshold: int,
 ) -> None:
-    """Retrieve messages from a DSpace Submission output queue and email the
-    results to stakeholders."""
-    date = datetime.today().strftime("%m-%d-%Y %H:%M:%S")
+    """Retrieve messages from an SQS queue and email the results to stakeholders."""
+    date = datetime.datetime.now(tz=datetime.UTC).strftime(config.DATE_FORMAT)
     stream = ctx.obj["stream"]
     sqs = SQS(ctx.obj["aws_region"])
     dynamodb_client = DynamoDB(ctx.obj["aws_region"])
@@ -312,17 +320,17 @@ def listen(
             try:
                 doi = sqs_message["MessageAttributes"]["PackageID"]["StringValue"]
             except KeyError:
-                logger.error(
+                logger.exception(
                     "Failed to get DOI from message attributes: %s", sqs_message
                 )
                 continue
             try:
                 body = json.loads(str(sqs_message.get("Body")))
             except ValueError:
-                logger.error(f"Failed to parse body of SQS message: {sqs_message}")
+                logger.exception("Failed to parse body of SQS message: %s", sqs_message)
                 continue
             if body["ResultType"] == "error":
-                logger.error(f"DOI: {doi}, Result: {body}")
+                logger.exception("DOI: %s, Result: %s", doi, body)
                 sqs.delete(
                     ctx.obj["sqs_base_url"],
                     ctx.obj["sqs_output_queue"],
@@ -339,14 +347,19 @@ def listen(
                         dynamodb_client.update_doi_item_status_in_database(
                             ctx.obj["doi_table"], doi, Status.UNPROCESSED.value
                         )
-                except KeyError as e:
-                    logger.error("Key error in table while processing %s: %s", doi, e)
+                except KeyError:
+                    logger.exception(
+                        "Key error in table while processing %s",
+                        doi,
+                    )
                 except ClientError as e:
-                    logger.error(
-                        f"Table error while processing {doi}: {e.response['Error']['Message']}"
+                    logger.exception(
+                        "Table error while processing %s: %s",
+                        doi,
+                        e.response["Error"]["Message"],
                     )
             else:
-                logger.info(f"DOI: {doi}, Result: {body}")
+                logger.info("DOI: %s, Result: %s", doi, body)
                 sqs.delete(
                     ctx.obj["sqs_base_url"],
                     ctx.obj["sqs_output_queue"],
@@ -356,16 +369,21 @@ def listen(
                     dynamodb_client.update_doi_item_status_in_database(
                         ctx.obj["doi_table"], doi, Status.SUCCESS.value
                     )
-                except KeyError as e:
-                    logger.error("Key error in table while processing %s: %s", doi, e)
+                except KeyError:
+                    logger.exception(
+                        "Key error in table while processing %s",
+                        doi,
+                    )
                 except ClientError as e:
-                    logger.error(
-                        f"Table error while processing {doi}: {e.response['Error']['Message']}"
+                    logger.exception(
+                        "Table error while processing %s: %s",
+                        doi,
+                        e.response["Error"]["Message"],
                     )
         logger.debug("Messages received and deleted from output queue")
     except ClientError as e:
-        logger.error(
-            f"Failure while retrieving SQS messages, {e.response['Error']['Message']}"
+        logger.exception(
+            "Failure while retrieving SQS messages: %s", e.response["Error"]["Message"]
         )
     ses_client = SES(ctx.obj["aws_region"])
     email_message = ses_client.create_email(
@@ -379,6 +397,6 @@ def listen(
             ctx.obj["log_recipient_email"],
             email_message,
         )
-        logger.debug(f"Logs sent to {ctx.obj['log_recipient_email']}")
+        logger.debug("Logs sent to %s", ctx.obj["log_recipient_email"])
     except ClientError as e:
-        logger.error(f"Failed to send logs: {e.response['Error']['Message']}")
+        logger.exception("Failed to send logs: %s", e.response["Error"]["Message"])

--- a/awd/config.py
+++ b/awd/config.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import os
-from typing import Optional
 
 ENV = os.getenv("WORKSPACE")
 
@@ -8,21 +9,23 @@ logger = logging.getLogger(__name__)
 logger.debug("Configuring awd for current env: %s", ENV)
 
 AWS_REGION_NAME = "us-east-1"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+STATUS_CODE_200 = 200
 
 if ENV == "test":
-    LOG_LEVEL: Optional[str] = "INFO"
-    DOI_TABLE: Optional[str] = "test_dois"
-    METADATA_URL: Optional[str] = "http://example.com/works/"
-    CONTENT_URL: Optional[str] = "http://example.com/doi/"
-    BUCKET: Optional[str] = "awd"
-    SQS_BASE_URL: Optional[str] = "https://queue.amazonaws.com/123456789012/"
-    SQS_INPUT_QUEUE: Optional[str] = "mock-input-queue"
-    SQS_OUTPUT_QUEUE: Optional[str] = "mock-output-queue"
-    COLLECTION_HANDLE: Optional[str] = "123.4/5678"
-    LOG_SOURCE_EMAIL: Optional[str] = "noreply@example.com"
-    LOG_RECIPIENT_EMAIL: Optional[str] = "mock@mock.mock"
-    RETRY_THRESHOLD: Optional[str] = "10"
-    SENTRY_DSN: Optional[str] = None
+    LOG_LEVEL: str | None = "INFO"
+    DOI_TABLE: str | None = "test_dois"
+    METADATA_URL: str | None = "http://example.com/works/"
+    CONTENT_URL: str | None = "http://example.com/doi/"
+    BUCKET: str | None = "awd"
+    SQS_BASE_URL: str | None = "https://queue.amazonaws.com/123456789012/"
+    SQS_INPUT_QUEUE: str | None = "mock-input-queue"
+    SQS_OUTPUT_QUEUE: str | None = "mock-output-queue"
+    COLLECTION_HANDLE: str | None = "123.4/5678"
+    LOG_SOURCE_EMAIL: str | None = "noreply@example.com"
+    LOG_RECIPIENT_EMAIL: str | None = "mock@mock.mock"
+    RETRY_THRESHOLD: str | None = "10"
+    SENTRY_DSN: str | None = None
 else:
     LOG_LEVEL = os.getenv("LOG_LEVEL")
     DOI_TABLE = os.getenv("DOI_TABLE")

--- a/awd/crossref.py
+++ b/awd/crossref.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 from typing import Any, Iterator
@@ -11,20 +13,18 @@ logger = logging.getLogger(__name__)
 def get_dois_from_spreadsheet(file: str) -> Iterator[str]:
     """Retriev DOIs from the Wiley-provided CSV file."""
     with smart_open.open(file, encoding="utf-8-sig") as csvfile:
-        for doi in csvfile.read().splitlines():
-            yield doi
+        yield from csvfile.read().splitlines()
 
 
 def get_work_record_from_doi(api_url: str, doi: str) -> dict[str, Any]:
-    """Retrieve Crossref works based on a DOI"""
-    work_record = requests.get(
+    """Retrieve Crossref works based on a DOI."""
+    return requests.get(
         f"{api_url}{doi}",
         params={
             "mailto": "dspace-lib@mit.edu",
         },
         timeout=30,
     ).json()
-    return work_record
 
 
 def get_metadata_extract_from(work_record: dict[str, Any]) -> dict[str, Any]:
@@ -46,7 +46,7 @@ def get_metadata_extract_from(work_record: dict[str, Any]) -> dict[str, Any]:
     ]
     work = work_record["message"]
     value_dict: dict[str, Any] = {}
-    for key in [k for k in work.keys() if k in keys_for_dspace]:
+    for key in [k for k in work if k in keys_for_dspace]:
         if key == "author":
             authors = []
             for author in work["author"]:
@@ -67,17 +67,19 @@ def create_dspace_metadata_from_dict(
     value_dict: dict[str, Any], metadata_mapping_path: str
 ) -> dict[str, Any]:
     """Create DSpace JSON metadata from metadata dict and a JSON metadata mapping file."""
-    with open(metadata_mapping_path, "r") as metadata_mapping_file:
+    with open(metadata_mapping_path) as metadata_mapping_file:
         metadata_mapping = json.load(metadata_mapping_file)
         metadata = []
-        for key in [k for k in metadata_mapping if k in value_dict.keys()]:
+        for key in [k for k in metadata_mapping if k in value_dict]:
             if isinstance(value_dict[key], list):
-                for list_item in value_dict[key]:
-                    metadata.append({"key": metadata_mapping[key], "value": list_item})
-            else:
-                metadata.append(
-                    {"key": metadata_mapping[key], "value": value_dict[key]}
+                metadata.extend(
+                    [
+                        {"key": metadata_mapping[key], "value": list_item}
+                        for list_item in value_dict[key]
+                    ]
                 )
+            else:
+                metadata.append({"key": metadata_mapping[key], "value": value_dict[key]})
         return {"metadata": metadata}
 
 
@@ -107,7 +109,7 @@ def is_valid_dspace_metadata(dspace_metadata: dict[str, Any]) -> bool:
                 is_valid = True
         logger.debug("Valid DSpace metadata generated")
     else:
-        logger.error(f"Invalid DSpace metadata generated: {dspace_metadata}")
+        logger.exception("Invalid DSpace metadata generated: %s ", dspace_metadata)
     return is_valid
 
 
@@ -119,7 +121,7 @@ def is_valid_response(doi: str, work_record: dict[str, Any]) -> bool:
         and work_record.get("message", {}).get("URL") is not None
     ):
         validation_status = True
-        logger.debug(f"Sufficient metadata downloaded for {doi}")
+        logger.debug("Sufficient metadata downloaded for %s", doi)
     else:
-        logger.error(f"Insufficient metadata for {doi}, missing title or URL")
+        logger.exception("Insufficient metadata for %s, missing title or URL", doi)
     return validation_status

--- a/awd/s3.py
+++ b/awd/s3.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 import logging
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 from boto3 import client
-from mypy_boto3_s3.type_defs import PutObjectOutputTypeDef
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.type_defs import PutObjectOutputTypeDef
 
 logger = logging.getLogger(__name__)
 
 
 class S3:
-    """An S3 class that provides a generic boto3 s3 client for interacting with S3
-    objects, along with specific S3 functionality necessary for Wiley deposits."""
+    """An S3 class that provides a generic boto3 s3 client.
+
+    Includes specific S3 functionality necessary for Wiley deposits.
+    """
 
     def __init__(self) -> None:
         self.client = client("s3")
@@ -17,24 +23,22 @@ class S3:
     def filter_files_in_bucket(
         self, bucket: str, file_type: str, excluded_prefix: str
     ) -> Iterator[str]:
-        """Retrieve file with the specified file extension in the specified bucket without
-        the excluded prefix."""
+        """Retrieve file based on file extension, bucket, and without excluded prefix."""
         paginator = self.client.get_paginator("list_objects_v2")
         pages = paginator.paginate(Bucket=bucket)
-        for object in [
-            object
+        for s3_object in [
+            s3_object
             for page in pages
-            for object in page["Contents"]
-            if object["Key"].endswith(file_type)
-            and excluded_prefix not in object["Key"]
+            for s3_object in page["Contents"]
+            if s3_object["Key"].endswith(file_type)
+            and excluded_prefix not in s3_object["Key"]
         ]:
-            yield object["Key"]
+            yield s3_object["Key"]
 
     def archive_file_with_new_key(
         self, bucket: str, key: str, archived_key_prefix: str
     ) -> None:
-        """Change the key of the specified file in the specified bucket to archive it from
-        processing"""
+        """Update the key of the specified file to archive it from processing."""
         self.client.copy_object(
             Bucket=bucket,
             CopySource=f"{bucket}/{key}",
@@ -54,5 +58,5 @@ class S3:
             Bucket=bucket,
             Key=key,
         )
-        logger.debug(f"{key} uploaded to S3")
+        logger.debug("%s uploaded to S3", key)
         return response

--- a/awd/ses.py
+++ b/awd/ses.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class SES:
     """An SES class that provides a generic boto3 SES client."""
 
-    def __init__(self, region) -> None:
+    def __init__(self, region: str) -> None:
         self.client = client("ses", region_name=region)
 
     def create_email(
@@ -34,11 +34,10 @@ class SES:
         self, source_email: str, recipient_email_address: str, message: MIMEMultipart
     ) -> SendRawEmailResponseTypeDef:
         """Send email via SES."""
-        response = self.client.send_raw_email(
+        return self.client.send_raw_email(
             Source=source_email,
             Destinations=[recipient_email_address],
             RawMessage={
                 "Data": message.as_string(),
             },
         )
-        return response

--- a/awd/sqs.py
+++ b/awd/sqs.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import json
 import logging
-from typing import Any, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, Iterator, Mapping
 
 from boto3 import client
-from mypy_boto3_sqs.type_defs import (
-    EmptyResponseMetadataTypeDef,
-    MessageAttributeValueTypeDef,
-    MessageTypeDef,
-    SendMessageResultTypeDef,
-)
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs.type_defs import (
+        EmptyResponseMetadataTypeDef,
+        MessageAttributeValueTypeDef,
+        MessageTypeDef,
+        SendMessageResultTypeDef,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +27,12 @@ class SQS:
         self, sqs_base_url: str, queue_name: str, receipt_handle: str
     ) -> EmptyResponseMetadataTypeDef:
         """Delete message from SQS queue."""
-        logger.debug(f"Deleting {receipt_handle} from SQS queue: {queue_name}")
+        logger.debug("Deleting %s from SQS queue: %s", receipt_handle, queue_name)
         response = self.client.delete_message(
             QueueUrl=f"{sqs_base_url}{queue_name}",
             ReceiptHandle=receipt_handle,
         )
-        logger.debug(f"Message deleted from SQS queue: {response}")
+        logger.debug("Message deleted from SQS queue: %s", response)
         return response
 
     def send(
@@ -39,13 +43,13 @@ class SQS:
         message_body: str,
     ) -> SendMessageResultTypeDef:
         """Send message via SQS."""
-        logger.debug(f"Sending message to SQS queue: {queue_name}")
+        logger.debug("Sending message to SQS queue: %s", queue_name)
         response = self.client.send_message(
             QueueUrl=f"{sqs_base_url}{queue_name}",
             MessageAttributes=message_attributes,
             MessageBody=str(message_body),
         )
-        logger.debug(f"Response from SQS queue: {response}")
+        logger.debug("Response from SQS queue: %s", response)
         return response
 
     def receive(
@@ -54,7 +58,7 @@ class SQS:
         queue_name: str,
     ) -> Iterator[MessageTypeDef]:
         """Receive message via SQS."""
-        logger.debug(f"Receiving messages from SQS queue: {queue_name}")
+        logger.debug("Receiving messages from SQS queue: %s", queue_name)
         while True:
             response = self.client.receive_message(
                 QueueUrl=f"{sqs_base_url}{queue_name}",
@@ -64,11 +68,11 @@ class SQS:
             if "Messages" in response:
                 for message in response["Messages"]:
                     logger.debug(
-                        f"Message retrieved from SQS queue {queue_name}: {message}"
+                        "Message retrieved from SQS queue %s: %s", queue_name, message
                     )
                     yield message
             else:
-                logger.debug(f"No more messages from SQS queue: {queue_name}")
+                logger.debug("No more messages from SQS queue: %s", queue_name)
                 break
 
 
@@ -76,12 +80,11 @@ def create_dss_message_attributes(
     package_id: str, submission_source: str, output_queue: str
 ) -> dict[str, Any]:
     """Create attributes for a DSpace Submission Service message."""
-    dss_message_attributes = {
+    return {
         "PackageID": {"DataType": "String", "StringValue": package_id},
         "SubmissionSource": {"DataType": "String", "StringValue": submission_source},
         "OutputQueue": {"DataType": "String", "StringValue": output_queue},
     }
-    return dss_message_attributes
 
 
 def create_dss_message_body(
@@ -92,16 +95,17 @@ def create_dss_message_body(
     bitstream_s3_uri: str,
 ) -> str:
     """Create body for a DSpace Submission Service message."""
-    dss_message_body = {
-        "SubmissionSystem": submission_system,
-        "CollectionHandle": collection_handle,
-        "MetadataLocation": metadata_s3_uri,
-        "Files": [
-            {
-                "BitstreamName": bitstream_name,
-                "FileLocation": bitstream_s3_uri,
-                "BitstreamDescription": None,
-            }
-        ],
-    }
-    return json.dumps(dss_message_body)
+    return json.dumps(
+        {
+            "SubmissionSystem": submission_system,
+            "CollectionHandle": collection_handle,
+            "MetadataLocation": metadata_s3_uri,
+            "Files": [
+                {
+                    "BitstreamName": bitstream_name,
+                    "FileLocation": bitstream_s3_uri,
+                    "BitstreamDescription": None,
+                }
+            ],
+        }
+    )

--- a/awd/wiley.py
+++ b/awd/wiley.py
@@ -23,9 +23,9 @@ def is_valid_response(doi: str, wiley_response: requests.Response) -> bool:
     validation_status = False
     if wiley_response.headers["content-type"] == "application/pdf; charset=UTF-8":
         validation_status = True
-        logger.debug(f"PDF downloaded for {doi}")
+        logger.debug("PDF downloaded for %s", doi)
     else:
-        logger.error(f"A PDF could not be retrieved for DOI: {doi}")
+        logger.exception("A PDF could not be retrieved for DOI: %s", doi)
         logger.debug(
             "Response contents retrieved from Wiley server for %s: %s",
             doi,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,65 @@
+[tool.black]
+line-length = 90
+
+[tool.mypy]
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+exclude = ["tests/"]
+
+[[tool.mypy.overrides]]
+module = "smart_open.*"
+ignore_missing_imports = true
+
+[tool.ruff]
+select = ["ALL", "PT"]
+
+ignore = [
+    # default
+    "ANN101", 
+    "ANN102", 
+    "COM812", 
+    "D107", 
+    "N812", 
+    "PTH", 
+
+    # project-specific
+    "C90",
+    "D100",
+    "D101", 
+    "D102",
+    "D103",
+    "D104", 
+    "PLR0912",
+    "PLR0913",
+    "PLR0915", 
+    "S320",
+    "S321", 
+]
+
+# allow autofix behavior for specified rules
+fixable = ["E", "F", "I", "Q"]
+
+# set max line length
+line-length = 90
+
+# enumerate all fixed violations
+show-fixes = true
+
+[tool.ruff.flake8-annotations]
+mypy-init-return = true
+
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = false
+
+[tool.ruff.per-file-ignores]
+"tests/**/*" = [
+    "ANN",
+    "ARG001",
+    "S101",
+]
+
+[tool.ruff.pycodestyle]
+max-doc-length = 90
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,20 +14,20 @@ from awd.ses import SES
 from awd.sqs import SQS
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def runner():
     return CliRunner()
 
 
-@pytest.fixture(scope="function")
-def aws_credentials():
+@pytest.fixture(autouse=True)
+def _aws_credentials():
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # noqa: S105
 
 
-@pytest.fixture()
-def test_aws_user(aws_credentials):
+@pytest.fixture
+def test_aws_user():
     with mock_iam():
         user_name = "test-user"
         policy_document = {
@@ -62,28 +62,28 @@ def test_aws_user(aws_credentials):
         yield client.create_access_key(UserName="test-user")["AccessKey"]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dynamodb_class():
     return DynamoDB(config.AWS_REGION_NAME)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def s3_class():
     return S3()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def ses_class():
     return SES(config.AWS_REGION_NAME)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def sqs_class():
     return SQS(config.AWS_REGION_NAME)
 
 
-@pytest.fixture(scope="function")
-def mocked_dynamodb(aws_credentials):
+@pytest.fixture
+def mocked_dynamodb():
     with mock_dynamodb():
         dynamodb = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb.create_table(
@@ -99,24 +99,24 @@ def mocked_dynamodb(aws_credentials):
         yield dynamodb
 
 
-@pytest.fixture(scope="function")
-def mocked_s3(aws_credentials):
+@pytest.fixture
+def mocked_s3():
     with mock_s3():
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="awd")
         yield s3
 
 
-@pytest.fixture(scope="function")
-def mocked_ses(aws_credentials):
+@pytest.fixture
+def mocked_ses():
     with mock_ses():
         ses = boto3.client("ses", region_name="us-east-1")
         ses.verify_email_identity(EmailAddress="noreply@example.com")
         yield ses
 
 
-@pytest.fixture(scope="function")
-def mocked_sqs(aws_credentials):
+@pytest.fixture
+def mocked_sqs():
     with mock_sqs():
         sqs = boto3.resource("sqs", region_name="us-east-1")
         sqs.create_queue(QueueName="mock-input-queue")
@@ -124,7 +124,7 @@ def mocked_sqs(aws_credentials):
         yield sqs
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_web(crossref_work_record, wiley_pdf):
     with requests_mock.Mocker() as m:
         request_headers = {
@@ -162,98 +162,120 @@ def mocked_web(crossref_work_record, wiley_pdf):
         yield m
 
 
-@pytest.fixture()
+@pytest.fixture
 def crossref_work_record():
-    return json.loads(open("tests/fixtures/crossref_work_record.json", "r").read())
+    with open("tests/fixtures/crossref_work_record.json") as work_record:
+        return json.loads(work_record.read())
 
 
-@pytest.fixture()
+@pytest.fixture
+def doi_list_insufficient_metadata():
+    with open("tests/fixtures/doi_insufficient_metadata.csv", "rb") as doi_list:
+        return doi_list.read()
+
+
+@pytest.fixture
+def doi_list_pdf_unavailable():
+    with open("tests/fixtures/doi_pdf_unavailable.csv", "rb") as doi_list:
+        return doi_list.read()
+
+
+@pytest.fixture
+def doi_list_success():
+    with open("tests/fixtures/doi_success.csv", "rb") as doi_list:
+        return doi_list.read()
+
+
+@pytest.fixture
 def crossref_value_dict():
-    return json.loads(open("tests/fixtures/crossref_value_dict.json", "r").read())
+    with open("tests/fixtures/crossref_value_dict.json") as value_dict:
+        return json.loads(value_dict.read())
 
 
-@pytest.fixture()
+@pytest.fixture
 def wiley_pdf():
-    return open("tests/fixtures/wiley.pdf", "rb").read()
+    with open("tests/fixtures/wiley.pdf", "rb") as pdf:
+        return pdf.read()
 
 
-@pytest.fixture()
+@pytest.fixture
 def dspace_metadata():
-    return json.loads(open("tests/fixtures/dspace_metadata.json", "r").read())
+    with open("tests/fixtures/dspace_metadata.json") as metadata:
+        return json.loads(metadata.read())
 
 
-@pytest.fixture()
+@pytest.fixture
 def result_failure_message_attributes():
-    result_message_attributes = {
+    return {
         "PackageID": {"DataType": "String", "StringValue": "222.2/2222"},
         "SubmissionSource": {"DataType": "String", "StringValue": "Submission system"},
     }
-    return result_message_attributes
 
 
-@pytest.fixture()
+@pytest.fixture
 def result_success_message_attributes():
-    result_message_attributes = {
+    return {
         "PackageID": {"DataType": "String", "StringValue": "111.1/1111"},
         "SubmissionSource": {"DataType": "String", "StringValue": "Submission system"},
     }
-    return result_message_attributes
 
 
-@pytest.fixture()
+@pytest.fixture
 def result_failure_message_body():
-    result_failure_message_body = {
-        "ResultType": "error",
-        "ErrorTimestamp": "Thu Sep 09 18:32:39 UTC 2021",
-        "ErrorInfo": "Error occurred while posting item to DSpace",
-        "ExceptionMessage": "500 Server Error: Internal Server Error",
-        "ExceptionTraceback": "Full unformatted stack trace of the Exception",
-    }
-    return json.dumps(result_failure_message_body)
+    return json.dumps(
+        {
+            "ResultType": "error",
+            "ErrorTimestamp": "Thu Sep 09 18:32:39 UTC 2021",
+            "ErrorInfo": "Error occurred while posting item to DSpace",
+            "ExceptionMessage": "500 Server Error: Internal Server Error",
+            "ExceptionTraceback": "Full unformatted stack trace of the Exception",
+        }
+    )
 
 
-@pytest.fixture()
+@pytest.fixture
 def result_success_message_body():
-    result_success_message_body = {
-        "ResultType": "success",
-        "ItemHandle": "1721.1/131022",
-        "lastModified": "Thu Sep 09 17:56:39 UTC 2021",
-        "Bitstreams": [
-            {
-                "BitstreamName": "10.1002-term.3131.pdf",
-                "BitstreamUUID": "a1b2c3d4e5",
-                "BitstreamChecksum": {
-                    "value": "a4e0f4930dfaff904fa3c6c85b0b8ecc",
-                    "checkSumAlgorithm": "MD5",
-                },
-            }
-        ],
-    }
-    return json.dumps(result_success_message_body)
+    return json.dumps(
+        {
+            "ResultType": "success",
+            "ItemHandle": "1721.1/131022",
+            "lastModified": "Thu Sep 09 17:56:39 UTC 2021",
+            "Bitstreams": [
+                {
+                    "BitstreamName": "10.1002-term.3131.pdf",
+                    "BitstreamUUID": "a1b2c3d4e5",
+                    "BitstreamChecksum": {
+                        "value": "a4e0f4930dfaff904fa3c6c85b0b8ecc",
+                        "checkSumAlgorithm": "MD5",
+                    },
+                }
+            ],
+        }
+    )
 
 
-@pytest.fixture()
+@pytest.fixture
 def submission_message_attributes():
-    submission_message_attributes = {
+    return {
         "PackageID": {"DataType": "String", "StringValue": "123"},
         "SubmissionSource": {"DataType": "String", "StringValue": "Submission system"},
         "OutputQueue": {"DataType": "String", "StringValue": "DSS queue"},
     }
-    return submission_message_attributes
 
 
-@pytest.fixture()
+@pytest.fixture
 def submission_message_body():
-    submission_message_body = {
-        "SubmissionSystem": "DSpace@MIT",
-        "CollectionHandle": "123.4/5678",
-        "MetadataLocation": "s3://awd/10.1002-term.3131.json",
-        "Files": [
-            {
-                "BitstreamName": "10.1002-term.3131.pdf",
-                "FileLocation": "s3://awd/10.1002-term.3131.pdf",
-                "BitstreamDescription": None,
-            }
-        ],
-    }
-    return json.dumps(submission_message_body)
+    return json.dumps(
+        {
+            "SubmissionSystem": "DSpace@MIT",
+            "CollectionHandle": "123.4/5678",
+            "MetadataLocation": "s3://awd/10.1002-term.3131.json",
+            "Files": [
+                {
+                    "BitstreamName": "10.1002-term.3131.pdf",
+                    "FileLocation": "s3://awd/10.1002-term.3131.pdf",
+                    "BitstreamDescription": None,
+                }
+            ],
+        }
+    )

--- a/tests/fixtures/crossref_value_dict.json
+++ b/tests/fixtures/crossref_value_dict.json
@@ -1,7 +1,7 @@
 {
   "publisher": "Wiley",
   "issue": "12",
-  "title": "Metal‐based nanoparticles for bone tissue engineering",
+  "title": "Metal nanoparticles for bone tissue engineering",
   "volume": "14",
   "author": [
     "Eivazzadeh‐Keihan, Reza",
@@ -17,12 +17,17 @@
     "Maleki, Ali",
     "Hamblin, Michael R."
   ],
-  "container-title": ["Journal of Tissue Engineering and Regenerative Medicine"],
+  "container-title": [
+    "Journal of Tissue Engineering and Regenerative Medicine"
+  ],
   "original-title": [],
   "language": "en",
   "subtitle": [],
   "short-title": [],
   "issued": "2020-09-30",
   "URL": "http://dx.doi.org/10.1002/term.3131",
-  "ISSN": ["1932-6254", "1932-7005"]
+  "ISSN": [
+    "1932-6254",
+    "1932-7005"
+  ]
 }

--- a/tests/fixtures/crossref_work_record.json
+++ b/tests/fixtures/crossref_work_record.json
@@ -5,7 +5,11 @@
   "message": {
     "indexed": {
       "date-parts": [
-        [2021, 7, 19]
+        [
+          2021,
+          7,
+          19
+        ]
       ],
       "date-time": "2021-07-19T06:24:53Z",
       "timestamp": 1626675893700
@@ -13,44 +17,66 @@
     "reference-count": 259,
     "publisher": "Wiley",
     "issue": "12",
-    "license": [{
-      "start": {
-        "date-parts": [
-          [2020, 9, 30]
-        ],
-        "date-time": "2020-09-30T00:00:00Z",
-        "timestamp": 1601424000000
+    "license": [
+      {
+        "start": {
+          "date-parts": [
+            [
+              2020,
+              9,
+              30
+            ]
+          ],
+          "date-time": "2020-09-30T00:00:00Z",
+          "timestamp": 1601424000000
+        },
+        "content-version": "vor",
+        "delay-in-days": 0,
+        "URL": "http://onlinelibrary.wiley.com/termsAndConditions#vor"
       },
-      "content-version": "vor",
-      "delay-in-days": 0,
-      "URL": "http://onlinelibrary.wiley.com/termsAndConditions#vor"
-    }, {
-      "start": {
-        "date-parts": [
-          [2020, 9, 30]
-        ],
-        "date-time": "2020-09-30T00:00:00Z",
-        "timestamp": 1601424000000
-      },
-      "content-version": "tdm",
-      "delay-in-days": 0,
-      "URL": "http://doi.wiley.com/10.1002/tdm_license_1.1"
-    }],
+      {
+        "start": {
+          "date-parts": [
+            [
+              2020,
+              9,
+              30
+            ]
+          ],
+          "date-time": "2020-09-30T00:00:00Z",
+          "timestamp": 1601424000000
+        },
+        "content-version": "tdm",
+        "delay-in-days": 0,
+        "URL": "http://doi.wiley.com/10.1002/tdm_license_1.1"
+      }
+    ],
     "content-domain": {
-      "domain": ["onlinelibrary.wiley.com"],
+      "domain": [
+        "onlinelibrary.wiley.com"
+      ],
       "crossmark-restriction": true
     },
-    "short-container-title": ["J Tissue Eng Regen Med"],
+    "short-container-title": [
+      "J Tissue Eng Regen Med"
+    ],
     "published-print": {
       "date-parts": [
-        [2020, 12]
+        [
+          2020,
+          12
+        ]
       ]
     },
     "DOI": "10.1002/term.3131",
     "type": "journal-article",
     "created": {
       "date-parts": [
-        [2020, 9, 28]
+        [
+          2020,
+          9,
+          28
+        ]
       ],
       "date-time": "2020-09-28T20:09:24Z",
       "timestamp": 1601323764000
@@ -59,1235 +85,1552 @@
     "update-policy": "http://dx.doi.org/10.1002/crossmark_policy",
     "source": "Crossref",
     "is-referenced-by-count": 14,
-    "title": ["Metal‐based nanoparticles for bone tissue engineering"],
+    "title": [
+      "Metal nanoparticles for bone tissue engineering"
+    ],
     "prefix": "10.1002",
     "volume": "14",
-    "author": [{
-      "ORCID": "http://orcid.org/0000-0002-1998-9926",
-      "authenticated-orcid": false,
-      "given": "Reza",
-      "family": "Eivazzadeh‐Keihan",
-      "sequence": "first",
-      "affiliation": [{
-        "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0002-6706-4231",
-      "authenticated-orcid": false,
-      "given": "Ehsan",
-      "family": "Bahojb Noruzi",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Faculty of Chemistry, Department of Inorganic Chemistry University of Tabriz  Tabriz Iran"
-      }, {
-        "name": "Drug Applied Research Center Tabriz University of Medical Sciences  Tabriz Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0002-0119-0331",
-      "authenticated-orcid": false,
-      "given": "Karim",
-      "family": "Khanmohammadi Chenab",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0001-7604-688X",
-      "authenticated-orcid": false,
-      "given": "Amir",
-      "family": "Jafari",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Department of Medical Nanotechnology, Faculty of Advanced Technology in Medicine Iran University of Medical Sciences  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0003-0860-2236",
-      "authenticated-orcid": false,
-      "given": "Fateme",
-      "family": "Radinekiyan",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0001-5150-6405",
-      "authenticated-orcid": false,
-      "given": "Seyed Masoud",
-      "family": "Hashemi",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0002-0465-5771",
-      "authenticated-orcid": false,
-      "given": "Farnoush",
-      "family": "Ahmadpour",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0003-4719-6998",
-      "authenticated-orcid": false,
-      "given": "Ali",
-      "family": "Behboudi",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Faculty of Chemical, Petroleum and Gas Engineering Iran University of Science and Technology  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0002-2897-0039",
-      "authenticated-orcid": false,
-      "given": "Jafar",
-      "family": "Mosafer",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Research Center of Advanced Technologies in Medicine Torbat Heydariyeh University of Medical Sciences  Torbat Heydariyeh Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0002-4515-8675",
-      "authenticated-orcid": false,
-      "given": "Ahad",
-      "family": "Mokhtarzadeh",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Immunology Research Center Tabriz University of Medical Sciences  Tabriz Iran"
-      }, {
-        "name": "Department of Biotechnology Higher Education Institute of Rab‐Rashid  Tabriz Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0001-5490-3350",
-      "authenticated-orcid": false,
-      "given": "Ali",
-      "family": "Maleki",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
-      }]
-    }, {
-      "ORCID": "http://orcid.org/0000-0001-6431-4605",
-      "authenticated-orcid": false,
-      "given": "Michael R.",
-      "family": "Hamblin",
-      "sequence": "additional",
-      "affiliation": [{
-        "name": "Wellman Center for Photomedicine Massachusetts General Hospital  Boston Massachusetts USA"
-      }, {
-        "name": "Department of Dermatology Harvard Medical School  Boston Massachusetts USA"
-      }, {
-        "name": "Harvard‐MIT Division of Health Sciences and Technology  Cambridge Massachusetts USA"
-      }]
-    }],
+    "author": [
+      {
+        "ORCID": "http://orcid.org/0000-0002-1998-9926",
+        "authenticated-orcid": false,
+        "given": "Reza",
+        "family": "Eivazzadeh‐Keihan",
+        "sequence": "first",
+        "affiliation": [
+          {
+            "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0002-6706-4231",
+        "authenticated-orcid": false,
+        "given": "Ehsan",
+        "family": "Bahojb Noruzi",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Faculty of Chemistry, Department of Inorganic Chemistry University of Tabriz  Tabriz Iran"
+          },
+          {
+            "name": "Drug Applied Research Center Tabriz University of Medical Sciences  Tabriz Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0002-0119-0331",
+        "authenticated-orcid": false,
+        "given": "Karim",
+        "family": "Khanmohammadi Chenab",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0001-7604-688X",
+        "authenticated-orcid": false,
+        "given": "Amir",
+        "family": "Jafari",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Department of Medical Nanotechnology, Faculty of Advanced Technology in Medicine Iran University of Medical Sciences  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0003-0860-2236",
+        "authenticated-orcid": false,
+        "given": "Fateme",
+        "family": "Radinekiyan",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0001-5150-6405",
+        "authenticated-orcid": false,
+        "given": "Seyed Masoud",
+        "family": "Hashemi",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0002-0465-5771",
+        "authenticated-orcid": false,
+        "given": "Farnoush",
+        "family": "Ahmadpour",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0003-4719-6998",
+        "authenticated-orcid": false,
+        "given": "Ali",
+        "family": "Behboudi",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Faculty of Chemical, Petroleum and Gas Engineering Iran University of Science and Technology  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0002-2897-0039",
+        "authenticated-orcid": false,
+        "given": "Jafar",
+        "family": "Mosafer",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Research Center of Advanced Technologies in Medicine Torbat Heydariyeh University of Medical Sciences  Torbat Heydariyeh Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0002-4515-8675",
+        "authenticated-orcid": false,
+        "given": "Ahad",
+        "family": "Mokhtarzadeh",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Immunology Research Center Tabriz University of Medical Sciences  Tabriz Iran"
+          },
+          {
+            "name": "Department of Biotechnology Higher Education Institute of Rab‐Rashid  Tabriz Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0001-5490-3350",
+        "authenticated-orcid": false,
+        "given": "Ali",
+        "family": "Maleki",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Catalysts and Organic Synthesis Research Laboratory, Department of Chemistry Iran University of Science and Technology  Tehran Iran"
+          }
+        ]
+      },
+      {
+        "ORCID": "http://orcid.org/0000-0001-6431-4605",
+        "authenticated-orcid": false,
+        "given": "Michael R.",
+        "family": "Hamblin",
+        "sequence": "additional",
+        "affiliation": [
+          {
+            "name": "Wellman Center for Photomedicine Massachusetts General Hospital  Boston Massachusetts USA"
+          },
+          {
+            "name": "Department of Dermatology Harvard Medical School  Boston Massachusetts USA"
+          },
+          {
+            "name": "Harvard‐MIT Division of Health Sciences and Technology  Cambridge Massachusetts USA"
+          }
+        ]
+      }
+    ],
     "member": "311",
     "published-online": {
       "date-parts": [
-        [2020, 9, 30]
+        [
+          2020,
+          9,
+          30
+        ]
       ]
     },
-    "reference": [{
-      "key": "e_1_2_9_2_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/adfm.201002662"
-    }, {
-      "key": "e_1_2_9_3_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s10856-010-4005-9"
-    }, {
-      "key": "e_1_2_9_4_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/0022-3913(93)90289-Z"
-    }, {
-      "key": "e_1_2_9_5_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/pc.25545"
-    }, {
-      "key": "e_1_2_9_6_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2016.09.039"
-    }, {
-      "key": "e_1_2_9_7_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/smll.200801546"
-    }, {
-      "key": "e_1_2_9_8_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijom.2016.01.004"
-    }, {
-      "key": "e_1_2_9_9_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3109/02656736.2013.826825"
-    }, {
-      "key": "e_1_2_9_10_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3389/fchem.2019.00663"
-    }, {
-      "key": "e_1_2_9_11_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3390/molecules25020370"
-    }, {
-      "key": "e_1_2_9_12_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2018.01.122"
-    }, {
-      "key": "e_1_2_9_13_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1142/S2010324719400034"
-    }, {
-      "key": "e_1_2_9_14_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jmri.24691"
-    }, {
-      "key": "e_1_2_9_15_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/nn505015e"
-    }, {
-      "key": "e_1_2_9_16_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.carbpol.2016.06.034"
-    }, {
-      "key": "e_1_2_9_17_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2016.11.052"
-    }, {
-      "key": "e_1_2_9_18_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C7NJ01246B"
-    }, {
-      "key": "e_1_2_9_19_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s00204-013-1079-4"
-    }, {
-      "key": "e_1_2_9_20_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/978-3-319-76090-2_10"
-    }, {
-      "key": "e_1_2_9_21_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbm.b.34185"
-    }, {
-      "key": "e_1_2_9_22_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s10856-014-5240-2"
-    }, {
-      "key": "e_1_2_9_23_1",
-      "doi-asserted-by": "crossref",
-      "first-page": "1",
-      "DOI": "10.1155/2013/976765",
-      "article-title": "Loss of RASSF1A expression in colorectal cancer and its association with K‐ras status",
-      "volume": "2013",
-      "author": "Cao D.",
-      "year": "2013",
-      "journal-title": "BioMed Research International"
-    }, {
-      "key": "e_1_2_9_24_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbm.b.33900"
-    }, {
-      "key": "e_1_2_9_25_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s11427-017-9287-8"
-    }, {
-      "key": "e_1_2_9_26_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/S0142-9612(03)00486-1"
-    }, {
-      "key": "e_1_2_9_27_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbm.a.34492"
-    }, {
-      "key": "e_1_2_9_28_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/acsami.8b17427"
-    }, {
-      "key": "e_1_2_9_29_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1371/journal.pone.0113426"
-    }, {
-      "key": "e_1_2_9_30_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C6NR06421C"
-    }, {
-      "key": "e_1_2_9_31_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.nano.2019.02.006"
-    }, {
-      "key": "e_1_2_9_32_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2015.12.005"
-    }, {
-      "key": "e_1_2_9_33_1",
-      "first-page": "4383",
-      "article-title": "Gold nanoparticles promote osteogenic differentiation in human adipose‐derived mesenchymal stem cells through the Wnt/β‐catenin signaling pathway",
-      "volume": "10",
-      "author": "Choi S. Y.",
-      "year": "2015",
-      "journal-title": "International Journal of Nanomedicine"
-    }, {
-      "key": "e_1_2_9_34_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.toxlet.2012.11.022"
-    }, {
-      "key": "e_1_2_9_35_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/S0142-9612(98)00182-3"
-    }, {
-      "key": "e_1_2_9_36_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2017.11.020"
-    }, {
-      "key": "e_1_2_9_37_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1166/jbn.2015.2065"
-    }, {
-      "key": "e_1_2_9_38_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/c0nr00598c"
-    }, {
-      "key": "e_1_2_9_39_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1166/jbn.2015.2115"
-    }, {
-      "key": "e_1_2_9_40_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biotechadv.2010.10.003"
-    }, {
-      "key": "e_1_2_9_41_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1111/ijac.13076"
-    }, {
-      "key": "e_1_2_9_42_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C1CS15166E"
-    }, {
-      "key": "e_1_2_9_43_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2019.110267"
-    }, {
-      "key": "e_1_2_9_44_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jare.2019.03.011"
-    }, {
-      "key": "e_1_2_9_45_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/open.202000005"
-    }, {
-      "key": "e_1_2_9_46_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.trac.2016.12.003"
-    }, {
-      "key": "e_1_2_9_47_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.trac.2018.03.019"
-    }, {
-      "key": "e_1_2_9_48_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.trac.2017.12.019"
-    }, {
-      "key": "e_1_2_9_49_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s00604-019-3420-y"
-    }, {
-      "key": "e_1_2_9_50_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s10853-019-04005-6"
-    }, {
-      "key": "e_1_2_9_51_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2019.08.031"
-    }, {
-      "key": "e_1_2_9_52_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1088/1748-605X/aad8cf"
-    }, {
-      "key": "e_1_2_9_53_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2011.10.013"
-    }, {
-      "key": "e_1_2_9_54_1",
-      "first-page": "2392",
-      "article-title": "The effect of Cu (II)‐loaded brushite scaffolds on growth and activity of osteoblastic cells",
-      "volume": "100",
-      "author": "Ewald A.",
-      "year": "2012",
-      "journal-title": "Journal of Biomedical Materials Research Part A"
-    }, {
-      "key": "e_1_2_9_55_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2014.10.045"
-    }, {
-      "key": "e_1_2_9_56_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ceramint.2013.10.004"
-    }, {
-      "key": "e_1_2_9_57_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3390/ma10101177"
-    }, {
-      "key": "e_1_2_9_58_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2011.07.016"
-    }, {
-      "key": "e_1_2_9_59_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.2533/chimia.2013.851"
-    }, {
-      "key": "e_1_2_9_60_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/adfm.201301121"
-    }, {
-      "key": "e_1_2_9_61_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1093/jac/dkh478"
-    }, {
-      "key": "e_1_2_9_62_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1111/j.1600-0501.2009.01734.x"
-    }, {
-      "key": "e_1_2_9_63_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2009.10.009"
-    }, {
-      "key": "e_1_2_9_64_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/anie.200904359"
-    }, {
-      "key": "e_1_2_9_65_1",
-      "first-page": "2",
-      "article-title": "BMPs and cancer: Is the risk real",
-      "volume": "1",
-      "author": "Gitelis S.",
-      "year": "2008",
-      "journal-title": "American Academy of Orthopaedic Surgeons"
-    }, {
-      "key": "e_1_2_9_66_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3390/ijms19030826"
-    }, {
-      "key": "e_1_2_9_67_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1177/1528083711414960"
-    }, {
-      "key": "e_1_2_9_68_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s00423-009-0472-1"
-    }, {
-      "key": "e_1_2_9_69_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.2174/1381612821666151027151702"
-    }, {
-      "key": "e_1_2_9_70_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.matchemphys.2017.10.080"
-    }, {
-      "key": "e_1_2_9_71_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.knee.2010.09.003"
-    }, {
-      "key": "e_1_2_9_72_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.2147/IJN.S153758"
-    }, {
-      "key": "e_1_2_9_73_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s10544-015-9993-2"
-    }, {
-      "key": "e_1_2_9_74_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2018.01.089"
-    }, {
-      "key": "e_1_2_9_75_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jmmm.2018.06.019"
-    }, {
-      "key": "e_1_2_9_76_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2016.03.002"
-    }, {
-      "key": "e_1_2_9_77_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ceramint.2014.10.153"
-    }, {
-      "key": "e_1_2_9_78_1",
-      "first-page": "1",
-      "article-title": "Toxicity of manufactured copper nanoparticles—A review",
-      "volume": "3",
-      "author": "Hejazy M.",
-      "year": "2018",
-      "journal-title": "Nanomedicine Research Journal"
-    }, {
-      "key": "e_1_2_9_79_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2011.06.043"
-    }, {
-      "key": "e_1_2_9_80_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C3TB21246G"
-    }, {
-      "key": "e_1_2_9_81_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1089/ten.tec.2014.0236"
-    }, {
-      "key": "e_1_2_9_82_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2013.08.026"
-    }, {
-      "key": "e_1_2_9_83_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/S0142-9612(03)00582-9"
-    }, {
-      "key": "e_1_2_9_84_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1371/journal.pone.0210285"
-    }, {
-      "key": "e_1_2_9_85_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s00253-013-5422-8"
-    }, {
-      "key": "e_1_2_9_86_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/pc.25098"
-    }, {
-      "key": "e_1_2_9_87_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2017.07.083"
-    }, {
-      "key": "e_1_2_9_88_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1166/jnn.2012.6574"
-    }, {
-      "key": "e_1_2_9_89_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2014.05.074"
-    }, {
-      "key": "e_1_2_9_90_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbm.b.10071"
-    }, {
-      "key": "e_1_2_9_91_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/(SICI)1097-4636(19991215)47:4<481::AID-JBM4>3.0.CO;2-Y"
-    }, {
-      "key": "e_1_2_9_92_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1038/jid.2014.281"
-    }, {
-      "key": "e_1_2_9_93_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1128/AEM.02001-07"
-    }, {
-      "key": "e_1_2_9_94_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1049/iet-nbt.2013.0067"
-    }, {
-      "key": "e_1_2_9_95_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.addr.2012.09.013"
-    }, {
-      "key": "e_1_2_9_96_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jallcom.2017.07.288"
-    }, {
-      "key": "e_1_2_9_97_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C9BM00558G"
-    }, {
-      "key": "e_1_2_9_98_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.copbio.2006.08.009"
-    }, {
-      "key": "e_1_2_9_99_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2014.04.012"
-    }, {
-      "key": "e_1_2_9_100_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C4BM00390J"
-    }, {
-      "key": "e_1_2_9_101_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C4RA00040D"
-    }, {
-      "key": "e_1_2_9_102_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.nano.2006.12.001"
-    }, {
-      "key": "e_1_2_9_103_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jopr.2013.02.021"
-    }, {
-      "key": "e_1_2_9_104_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3109/21691401.2014.982799"
-    }, {
-      "key": "e_1_2_9_105_1",
-      "first-page": "1",
-      "article-title": "Magnetic nanoparticles in cancer therapy: How can thermal approaches help?",
-      "volume": "12",
-      "author": "Kolosnjaj‐Tabi J.",
-      "year": "2017",
-      "journal-title": "Future Medicine"
-    }, {
-      "key": "e_1_2_9_106_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s11999-014-4020-0"
-    }, {
-      "key": "e_1_2_9_107_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1089/ten.2006.0394"
-    }, {
-      "key": "e_1_2_9_108_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2019.01.064"
-    }, {
-      "key": "e_1_2_9_109_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.nano.2011.01.003"
-    }, {
-      "key": "e_1_2_9_110_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3390/polym10070804"
-    }, {
-      "key": "e_1_2_9_111_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.drudis.2014.01.012"
-    }, {
-      "key": "e_1_2_9_112_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jiec.2018.05.030"
-    }, {
-      "key": "e_1_2_9_113_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.2147/IJN.S112415"
-    }, {
-      "key": "e_1_2_9_114_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2017.03.014"
-    }, {
-      "key": "e_1_2_9_115_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C5TB01784J"
-    }, {
-      "key": "e_1_2_9_116_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2016.03.011"
-    }, {
-      "key": "e_1_2_9_117_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2013.03.052"
-    }, {
-      "key": "e_1_2_9_118_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/cphc.201701294"
-    }, {
-      "key": "e_1_2_9_119_1",
-      "first-page": "797S",
-      "article-title": "Copper biochemistry and molecular biology",
-      "volume": "63",
-      "author": "Linder M. C.",
-      "year": "1996",
-      "journal-title": "The American Journal of Clinical Nutrition"
-    }, {
-      "key": "e_1_2_9_120_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2010.11.001"
-    }, {
-      "key": "e_1_2_9_121_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s11434-010-0046-1"
-    }, {
-      "key": "e_1_2_9_122_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2006.03.007"
-    }, {
-      "key": "e_1_2_9_123_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/cmdc.200900502"
-    }, {
-      "key": "e_1_2_9_124_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.apsusc.2018.12.216"
-    }, {
-      "key": "e_1_2_9_125_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2018.05.041"
-    }, {
-      "key": "e_1_2_9_126_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1089/ten.teb.2012.0437"
-    }, {
-      "key": "e_1_2_9_127_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jconrel.2010.06.011"
-    }, {
-      "key": "e_1_2_9_128_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1080/21691401.2018.1465947"
-    }, {
-      "key": "e_1_2_9_129_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C5NR04003E"
-    }, {
-      "key": "e_1_2_9_130_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1088/1748-6041/10/3/035013"
-    }, {
-      "key": "e_1_2_9_131_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbm.b.34130"
-    }, {
-      "key": "e_1_2_9_132_1",
-      "first-page": "68",
-      "article-title": "Bone regeneration using bio‐nanocomposite tissue reinforced with bioactive nanoparticles for femoral defect applications in medicine",
-      "volume": "12",
-      "author": "Maghsoudlou M. A.",
-      "year": "2020",
-      "journal-title": "Avicenna Journal of Medical Biotechnology"
-    }, {
-      "key": "e_1_2_9_133_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ultsonch.2017.01.022"
-    }, {
-      "key": "e_1_2_9_134_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.catcom.2014.05.004"
-    }, {
-      "key": "e_1_2_9_135_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1049/mnl.2017.0560"
-    }, {
-      "key": "e_1_2_9_136_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1177/0885328219835995"
-    }, {
-      "key": "e_1_2_9_137_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1177/0363546512439026"
-    }, {
-      "key": "e_1_2_9_138_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2018.03.128"
-    }, {
-      "key": "e_1_2_9_139_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.trac.2017.10.005"
-    }, {
-      "key": "e_1_2_9_140_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ceramint.2018.10.016"
-    }, {
-      "key": "e_1_2_9_141_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s12178-011-9095-6"
-    }, {
-      "key": "e_1_2_9_142_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1088/0957-4484/16/10/059"
-    }, {
-      "key": "e_1_2_9_143_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jcp.28457"
-    }, {
-      "key": "e_1_2_9_144_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3349/ymj.2000.41.6.735"
-    }, {
-      "key": "e_1_2_9_145_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1038/sj.ejcn.1601867"
-    }, {
-      "key": "e_1_2_9_146_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/S1369-7021(11)70058-X"
-    }, {
-      "key": "e_1_2_9_147_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2006.07.034"
-    }, {
-      "key": "e_1_2_9_148_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.nano.2011.03.002"
-    }, {
-      "key": "e_1_2_9_149_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s10934-013-9757-4"
-    }, {
-      "key": "e_1_2_9_150_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ajodo.2011.02.021"
-    }, {
-      "key": "e_1_2_9_151_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.11607/jomi.4366"
-    }, {
-      "key": "e_1_2_9_152_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1080/10408390500466174"
-    }, {
-      "key": "e_1_2_9_153_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/smll.200700378"
-    }, {
-      "key": "e_1_2_9_154_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s00264-013-1917-2"
-    }, {
-      "key": "e_1_2_9_155_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/adma.200800004"
-    }, {
-      "key": "e_1_2_9_156_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2018.12.067"
-    }, {
-      "key": "e_1_2_9_157_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.nano.2007.03.005"
-    }, {
-      "key": "e_1_2_9_158_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2011.09.016"
-    }, {
-      "key": "e_1_2_9_159_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/S0142-9612(02)00352-6"
-    }, {
-      "key": "e_1_2_9_160_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s10971-015-3697-1"
-    }, {
-      "key": "e_1_2_9_161_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.carbpol.2014.03.041"
-    }, {
-      "key": "e_1_2_9_162_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2018.11.256"
-    }, {
-      "key": "e_1_2_9_163_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3109/17435390903337693"
-    }, {
-      "key": "e_1_2_9_164_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C5RA09560C"
-    }, {
-      "key": "e_1_2_9_165_1",
-      "volume-title": "Efeito da incorporação de dióxido de zircônio nanoestruturado em uma resina adesiva experimental",
-      "author": "Provenzi C.",
-      "year": "2014"
-    }, {
-      "key": "e_1_2_9_166_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3390/ijms20020435"
-    }, {
-      "key": "e_1_2_9_167_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2010.06.051"
-    }, {
-      "key": "e_1_2_9_168_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2019.03.092"
-    }, {
-      "key": "e_1_2_9_169_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C8NJ01790E"
-    }, {
-      "key": "e_1_2_9_170_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.2147/IJN.S194596"
-    }, {
-      "key": "e_1_2_9_171_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.carbpol.2019.115696"
-    }, {
-      "key": "e_1_2_9_172_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C7PY01701D"
-    }, {
-      "key": "e_1_2_9_173_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.carbpol.2018.05.059"
-    }, {
-      "key": "e_1_2_9_174_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s00264-010-1154-x"
-    }, {
-      "key": "e_1_2_9_175_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.apsusc.2013.09.160"
-    }, {
-      "key": "e_1_2_9_176_1",
-      "volume-title": "VI Latin American Congress on Biomedical Engineering CLAIB 2014, Paraná, Argentina 29, 30 & 31 October 2014",
-      "author": "Restrepo N.",
-      "year": "2015"
-    }, {
-      "key": "e_1_2_9_177_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.22203/eCM.v015a03"
-    }, {
-      "key": "e_1_2_9_178_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jcb.10111"
-    }, {
-      "key": "e_1_2_9_179_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1093/jac/dkn034"
-    }, {
-      "key": "e_1_2_9_180_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2012.07.036"
-    }, {
-      "key": "e_1_2_9_181_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2010.03.058"
-    }, {
-      "key": "e_1_2_9_182_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1097/00003086-200211000-00020"
-    }, {
-      "key": "e_1_2_9_183_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.4172/1948-593X.1000049"
-    }, {
-      "key": "e_1_2_9_184_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1038/7385"
-    }, {
-      "key": "e_1_2_9_185_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbm.a.30889"
-    }, {
-      "key": "e_1_2_9_186_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1111/hiv.12822"
-    }, {
-      "key": "e_1_2_9_187_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1140/epjp/i2019-12375-x"
-    }, {
-      "key": "e_1_2_9_188_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2007.06.015"
-    }, {
-      "key": "e_1_2_9_189_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jbiosc.2019.04.017"
-    }, {
-      "key": "e_1_2_9_190_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/acsami.5b00529"
-    }, {
-      "key": "e_1_2_9_191_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2011.04.010"
-    }, {
-      "key": "e_1_2_9_192_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/S1079-2104(00)80022-0"
-    }, {
-      "key": "e_1_2_9_193_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3390/app8020172"
-    }, {
-      "key": "e_1_2_9_194_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ica.2015.07.003"
-    }, {
-      "key": "e_1_2_9_195_1",
-      "first-page": "3",
-      "article-title": "Kinetics analysis of electrophoretic deposition using small and large signal modeling: The case study of nano‐mullite suspension",
-      "volume": "4",
-      "author": "Shakeri M. S.",
-      "year": "2016",
-      "journal-title": "Journal of Advanced Materials and Processing"
-    }, {
-      "key": "e_1_2_9_196_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/nn300445d"
-    }, {
-      "key": "e_1_2_9_197_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1097/00007632-200301150-00008"
-    }, {
-      "key": "e_1_2_9_198_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1177/0885328217738006"
-    }, {
-      "key": "e_1_2_9_199_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/nn301714n"
-    }, {
-      "key": "e_1_2_9_200_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2017.07.078"
-    }, {
-      "key": "e_1_2_9_201_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C6RA15267H"
-    }, {
-      "key": "e_1_2_9_202_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbio.201400064"
-    }, {
-      "key": "e_1_2_9_203_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.apsusc.2010.03.124"
-    }, {
-      "key": "e_1_2_9_204_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.etap.2015.02.003"
-    }, {
-      "key": "e_1_2_9_205_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/jbm.a.36707"
-    }, {
-      "key": "e_1_2_9_206_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/cmdc.200600171"
-    }, {
-      "key": "e_1_2_9_207_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.jtemb.2017.05.002"
-    }, {
-      "key": "e_1_2_9_208_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1155/2013/465086"
-    }, {
-      "key": "e_1_2_9_209_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ijbiomac.2011.11.013"
-    }, {
-      "key": "e_1_2_9_210_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/S0140-6736(99)90247-7"
-    }, {
-      "key": "e_1_2_9_211_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.addr.2009.11.002"
-    }, {
-      "key": "e_1_2_9_212_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.arthro.2013.02.025"
-    }, {
-      "key": "e_1_2_9_213_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C5RA13556G"
-    }, {
-      "key": "e_1_2_9_214_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/btpr.2469"
-    }, {
-      "key": "e_1_2_9_215_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2013.08.009"
-    }, {
-      "key": "e_1_2_9_216_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.nano.2015.02.013"
-    }, {
-      "key": "e_1_2_9_217_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2012.09.021"
-    }, {
-      "key": "e_1_2_9_218_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/acsami.5b02893"
-    }, {
-      "key": "e_1_2_9_219_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2011.04.006"
-    }, {
-      "key": "e_1_2_9_220_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2009.09.021"
-    }, {
-      "key": "e_1_2_9_221_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1557/jmr.2015.243"
-    }, {
-      "key": "e_1_2_9_222_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1166/jbn.2012.1437"
-    }, {
-      "key": "e_1_2_9_223_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1002/marc.201800062"
-    }, {
-      "key": "e_1_2_9_224_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/b712179m"
-    }, {
-      "key": "e_1_2_9_225_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/0142-9612(96)85753-X"
-    }, {
-      "key": "e_1_2_9_226_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1088/0957-4484/24/39/395101"
-    }, {
-      "key": "e_1_2_9_227_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.actbio.2011.06.028"
-    }, {
-      "key": "e_1_2_9_228_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.carbon.2015.04.048"
-    }, {
-      "key": "e_1_2_9_229_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2012.09.066"
-    }, {
-      "key": "e_1_2_9_230_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/c3tb20261e"
-    }, {
-      "key": "e_1_2_9_231_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2018.12.120"
-    }, {
-      "key": "e_1_2_9_232_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C5NR01107H"
-    }, {
-      "key": "e_1_2_9_233_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/nl301934w"
-    }, {
-      "key": "e_1_2_9_234_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C5NR07023F"
-    }, {
-      "key": "e_1_2_9_235_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C6TB01282E"
-    }, {
-      "key": "e_1_2_9_236_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.2147/IJN.S184396"
-    }, {
-      "key": "e_1_2_9_237_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.13005/ojc/310173"
-    }, {
-      "key": "e_1_2_9_238_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.surfcoat.2006.07.058"
-    }, {
-      "key": "e_1_2_9_239_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.apsusc.2014.07.027"
-    }, {
-      "key": "e_1_2_9_240_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2012.10.058"
-    }, {
-      "key": "e_1_2_9_241_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.matlet.2014.09.078"
-    }, {
-      "key": "e_1_2_9_242_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.polymertesting.2019.03.008"
-    }, {
-      "key": "e_1_2_9_243_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.bios.2017.08.018"
-    }, {
-      "key": "e_1_2_9_244_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.biomaterials.2011.03.053"
-    }, {
-      "key": "e_1_2_9_245_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/nn101373r"
-    }, {
-      "key": "e_1_2_9_246_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ceramint.2019.11.282"
-    }, {
-      "key": "e_1_2_9_247_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.3390/ijms13055554"
-    }, {
-      "key": "e_1_2_9_248_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1007/s12274-016-1265-9"
-    }, {
-      "key": "e_1_2_9_249_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2014.04.042"
-    }, {
-      "key": "e_1_2_9_250_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C4TB01063A"
-    }, {
-      "key": "e_1_2_9_251_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.watres.2012.01.015"
-    }, {
-      "key": "e_1_2_9_252_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.nano.2015.07.016"
-    }, {
-      "key": "e_1_2_9_253_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1038/ncomms10376"
-    }, {
-      "key": "e_1_2_9_254_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.2147/IJN.S21657"
-    }, {
-      "key": "e_1_2_9_255_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.ceramint.2013.01.094"
-    }, {
-      "key": "e_1_2_9_256_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1039/C6TB00390G"
-    }, {
-      "key": "e_1_2_9_257_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.colsurfb.2018.11.003"
-    }, {
-      "key": "e_1_2_9_258_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1016/j.msec.2019.109764"
-    }, {
-      "key": "e_1_2_9_259_1",
-      "doi-asserted-by": "publisher",
-      "DOI": "10.1021/acsbiomaterials.8b00986"
-    }, {
-      "key": "e_1_2_9_260_1",
-      "first-page": "475",
-      "article-title": "Role of prostaglandin E1 and copper in angiogenesis",
-      "volume": "69",
-      "author": "Ziche M.",
-      "year": "1982",
-      "journal-title": "Journal of the National Cancer Institute"
-    }],
-    "container-title": ["Journal of Tissue Engineering and Regenerative Medicine"],
+    "reference": [
+      {
+        "key": "e_1_2_9_2_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/adfm.201002662"
+      },
+      {
+        "key": "e_1_2_9_3_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s10856-010-4005-9"
+      },
+      {
+        "key": "e_1_2_9_4_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/0022-3913(93)90289-Z"
+      },
+      {
+        "key": "e_1_2_9_5_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/pc.25545"
+      },
+      {
+        "key": "e_1_2_9_6_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2016.09.039"
+      },
+      {
+        "key": "e_1_2_9_7_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/smll.200801546"
+      },
+      {
+        "key": "e_1_2_9_8_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijom.2016.01.004"
+      },
+      {
+        "key": "e_1_2_9_9_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3109/02656736.2013.826825"
+      },
+      {
+        "key": "e_1_2_9_10_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3389/fchem.2019.00663"
+      },
+      {
+        "key": "e_1_2_9_11_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3390/molecules25020370"
+      },
+      {
+        "key": "e_1_2_9_12_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2018.01.122"
+      },
+      {
+        "key": "e_1_2_9_13_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1142/S2010324719400034"
+      },
+      {
+        "key": "e_1_2_9_14_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jmri.24691"
+      },
+      {
+        "key": "e_1_2_9_15_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/nn505015e"
+      },
+      {
+        "key": "e_1_2_9_16_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.carbpol.2016.06.034"
+      },
+      {
+        "key": "e_1_2_9_17_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2016.11.052"
+      },
+      {
+        "key": "e_1_2_9_18_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C7NJ01246B"
+      },
+      {
+        "key": "e_1_2_9_19_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s00204-013-1079-4"
+      },
+      {
+        "key": "e_1_2_9_20_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/978-3-319-76090-2_10"
+      },
+      {
+        "key": "e_1_2_9_21_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbm.b.34185"
+      },
+      {
+        "key": "e_1_2_9_22_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s10856-014-5240-2"
+      },
+      {
+        "key": "e_1_2_9_23_1",
+        "doi-asserted-by": "crossref",
+        "first-page": "1",
+        "DOI": "10.1155/2013/976765",
+        "article-title": "Loss of RASSF1A expression in colorectal cancer and its association with K‐ras status",
+        "volume": "2013",
+        "author": "Cao D.",
+        "year": "2013",
+        "journal-title": "BioMed Research International"
+      },
+      {
+        "key": "e_1_2_9_24_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbm.b.33900"
+      },
+      {
+        "key": "e_1_2_9_25_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s11427-017-9287-8"
+      },
+      {
+        "key": "e_1_2_9_26_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/S0142-9612(03)00486-1"
+      },
+      {
+        "key": "e_1_2_9_27_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbm.a.34492"
+      },
+      {
+        "key": "e_1_2_9_28_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/acsami.8b17427"
+      },
+      {
+        "key": "e_1_2_9_29_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1371/journal.pone.0113426"
+      },
+      {
+        "key": "e_1_2_9_30_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C6NR06421C"
+      },
+      {
+        "key": "e_1_2_9_31_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.nano.2019.02.006"
+      },
+      {
+        "key": "e_1_2_9_32_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2015.12.005"
+      },
+      {
+        "key": "e_1_2_9_33_1",
+        "first-page": "4383",
+        "article-title": "Gold nanoparticles promote osteogenic differentiation in human adipose‐derived mesenchymal stem cells through the Wnt/β‐catenin signaling pathway",
+        "volume": "10",
+        "author": "Choi S. Y.",
+        "year": "2015",
+        "journal-title": "International Journal of Nanomedicine"
+      },
+      {
+        "key": "e_1_2_9_34_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.toxlet.2012.11.022"
+      },
+      {
+        "key": "e_1_2_9_35_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/S0142-9612(98)00182-3"
+      },
+      {
+        "key": "e_1_2_9_36_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2017.11.020"
+      },
+      {
+        "key": "e_1_2_9_37_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1166/jbn.2015.2065"
+      },
+      {
+        "key": "e_1_2_9_38_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/c0nr00598c"
+      },
+      {
+        "key": "e_1_2_9_39_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1166/jbn.2015.2115"
+      },
+      {
+        "key": "e_1_2_9_40_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biotechadv.2010.10.003"
+      },
+      {
+        "key": "e_1_2_9_41_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1111/ijac.13076"
+      },
+      {
+        "key": "e_1_2_9_42_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C1CS15166E"
+      },
+      {
+        "key": "e_1_2_9_43_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2019.110267"
+      },
+      {
+        "key": "e_1_2_9_44_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jare.2019.03.011"
+      },
+      {
+        "key": "e_1_2_9_45_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/open.202000005"
+      },
+      {
+        "key": "e_1_2_9_46_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.trac.2016.12.003"
+      },
+      {
+        "key": "e_1_2_9_47_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.trac.2018.03.019"
+      },
+      {
+        "key": "e_1_2_9_48_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.trac.2017.12.019"
+      },
+      {
+        "key": "e_1_2_9_49_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s00604-019-3420-y"
+      },
+      {
+        "key": "e_1_2_9_50_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s10853-019-04005-6"
+      },
+      {
+        "key": "e_1_2_9_51_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2019.08.031"
+      },
+      {
+        "key": "e_1_2_9_52_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1088/1748-605X/aad8cf"
+      },
+      {
+        "key": "e_1_2_9_53_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2011.10.013"
+      },
+      {
+        "key": "e_1_2_9_54_1",
+        "first-page": "2392",
+        "article-title": "The effect of Cu (II)‐loaded brushite scaffolds on growth and activity of osteoblastic cells",
+        "volume": "100",
+        "author": "Ewald A.",
+        "year": "2012",
+        "journal-title": "Journal of Biomedical Materials Research Part A"
+      },
+      {
+        "key": "e_1_2_9_55_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2014.10.045"
+      },
+      {
+        "key": "e_1_2_9_56_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ceramint.2013.10.004"
+      },
+      {
+        "key": "e_1_2_9_57_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3390/ma10101177"
+      },
+      {
+        "key": "e_1_2_9_58_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2011.07.016"
+      },
+      {
+        "key": "e_1_2_9_59_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.2533/chimia.2013.851"
+      },
+      {
+        "key": "e_1_2_9_60_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/adfm.201301121"
+      },
+      {
+        "key": "e_1_2_9_61_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1093/jac/dkh478"
+      },
+      {
+        "key": "e_1_2_9_62_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1111/j.1600-0501.2009.01734.x"
+      },
+      {
+        "key": "e_1_2_9_63_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2009.10.009"
+      },
+      {
+        "key": "e_1_2_9_64_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/anie.200904359"
+      },
+      {
+        "key": "e_1_2_9_65_1",
+        "first-page": "2",
+        "article-title": "BMPs and cancer: Is the risk real",
+        "volume": "1",
+        "author": "Gitelis S.",
+        "year": "2008",
+        "journal-title": "American Academy of Orthopaedic Surgeons"
+      },
+      {
+        "key": "e_1_2_9_66_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3390/ijms19030826"
+      },
+      {
+        "key": "e_1_2_9_67_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1177/1528083711414960"
+      },
+      {
+        "key": "e_1_2_9_68_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s00423-009-0472-1"
+      },
+      {
+        "key": "e_1_2_9_69_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.2174/1381612821666151027151702"
+      },
+      {
+        "key": "e_1_2_9_70_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.matchemphys.2017.10.080"
+      },
+      {
+        "key": "e_1_2_9_71_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.knee.2010.09.003"
+      },
+      {
+        "key": "e_1_2_9_72_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.2147/IJN.S153758"
+      },
+      {
+        "key": "e_1_2_9_73_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s10544-015-9993-2"
+      },
+      {
+        "key": "e_1_2_9_74_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2018.01.089"
+      },
+      {
+        "key": "e_1_2_9_75_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jmmm.2018.06.019"
+      },
+      {
+        "key": "e_1_2_9_76_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2016.03.002"
+      },
+      {
+        "key": "e_1_2_9_77_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ceramint.2014.10.153"
+      },
+      {
+        "key": "e_1_2_9_78_1",
+        "first-page": "1",
+        "article-title": "Toxicity of manufactured copper nanoparticles—A review",
+        "volume": "3",
+        "author": "Hejazy M.",
+        "year": "2018",
+        "journal-title": "Nanomedicine Research Journal"
+      },
+      {
+        "key": "e_1_2_9_79_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2011.06.043"
+      },
+      {
+        "key": "e_1_2_9_80_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C3TB21246G"
+      },
+      {
+        "key": "e_1_2_9_81_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1089/ten.tec.2014.0236"
+      },
+      {
+        "key": "e_1_2_9_82_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2013.08.026"
+      },
+      {
+        "key": "e_1_2_9_83_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/S0142-9612(03)00582-9"
+      },
+      {
+        "key": "e_1_2_9_84_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1371/journal.pone.0210285"
+      },
+      {
+        "key": "e_1_2_9_85_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s00253-013-5422-8"
+      },
+      {
+        "key": "e_1_2_9_86_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/pc.25098"
+      },
+      {
+        "key": "e_1_2_9_87_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2017.07.083"
+      },
+      {
+        "key": "e_1_2_9_88_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1166/jnn.2012.6574"
+      },
+      {
+        "key": "e_1_2_9_89_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2014.05.074"
+      },
+      {
+        "key": "e_1_2_9_90_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbm.b.10071"
+      },
+      {
+        "key": "e_1_2_9_91_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/(SICI)1097-4636(19991215)47:4<481::AID-JBM4>3.0.CO;2-Y"
+      },
+      {
+        "key": "e_1_2_9_92_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1038/jid.2014.281"
+      },
+      {
+        "key": "e_1_2_9_93_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1128/AEM.02001-07"
+      },
+      {
+        "key": "e_1_2_9_94_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1049/iet-nbt.2013.0067"
+      },
+      {
+        "key": "e_1_2_9_95_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.addr.2012.09.013"
+      },
+      {
+        "key": "e_1_2_9_96_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jallcom.2017.07.288"
+      },
+      {
+        "key": "e_1_2_9_97_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C9BM00558G"
+      },
+      {
+        "key": "e_1_2_9_98_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.copbio.2006.08.009"
+      },
+      {
+        "key": "e_1_2_9_99_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2014.04.012"
+      },
+      {
+        "key": "e_1_2_9_100_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C4BM00390J"
+      },
+      {
+        "key": "e_1_2_9_101_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C4RA00040D"
+      },
+      {
+        "key": "e_1_2_9_102_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.nano.2006.12.001"
+      },
+      {
+        "key": "e_1_2_9_103_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jopr.2013.02.021"
+      },
+      {
+        "key": "e_1_2_9_104_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3109/21691401.2014.982799"
+      },
+      {
+        "key": "e_1_2_9_105_1",
+        "first-page": "1",
+        "article-title": "Magnetic nanoparticles in cancer therapy: How can thermal approaches help?",
+        "volume": "12",
+        "author": "Kolosnjaj‐Tabi J.",
+        "year": "2017",
+        "journal-title": "Future Medicine"
+      },
+      {
+        "key": "e_1_2_9_106_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s11999-014-4020-0"
+      },
+      {
+        "key": "e_1_2_9_107_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1089/ten.2006.0394"
+      },
+      {
+        "key": "e_1_2_9_108_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2019.01.064"
+      },
+      {
+        "key": "e_1_2_9_109_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.nano.2011.01.003"
+      },
+      {
+        "key": "e_1_2_9_110_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3390/polym10070804"
+      },
+      {
+        "key": "e_1_2_9_111_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.drudis.2014.01.012"
+      },
+      {
+        "key": "e_1_2_9_112_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jiec.2018.05.030"
+      },
+      {
+        "key": "e_1_2_9_113_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.2147/IJN.S112415"
+      },
+      {
+        "key": "e_1_2_9_114_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2017.03.014"
+      },
+      {
+        "key": "e_1_2_9_115_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C5TB01784J"
+      },
+      {
+        "key": "e_1_2_9_116_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2016.03.011"
+      },
+      {
+        "key": "e_1_2_9_117_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2013.03.052"
+      },
+      {
+        "key": "e_1_2_9_118_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/cphc.201701294"
+      },
+      {
+        "key": "e_1_2_9_119_1",
+        "first-page": "797S",
+        "article-title": "Copper biochemistry and molecular biology",
+        "volume": "63",
+        "author": "Linder M. C.",
+        "year": "1996",
+        "journal-title": "The American Journal of Clinical Nutrition"
+      },
+      {
+        "key": "e_1_2_9_120_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2010.11.001"
+      },
+      {
+        "key": "e_1_2_9_121_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s11434-010-0046-1"
+      },
+      {
+        "key": "e_1_2_9_122_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2006.03.007"
+      },
+      {
+        "key": "e_1_2_9_123_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/cmdc.200900502"
+      },
+      {
+        "key": "e_1_2_9_124_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.apsusc.2018.12.216"
+      },
+      {
+        "key": "e_1_2_9_125_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2018.05.041"
+      },
+      {
+        "key": "e_1_2_9_126_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1089/ten.teb.2012.0437"
+      },
+      {
+        "key": "e_1_2_9_127_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jconrel.2010.06.011"
+      },
+      {
+        "key": "e_1_2_9_128_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1080/21691401.2018.1465947"
+      },
+      {
+        "key": "e_1_2_9_129_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C5NR04003E"
+      },
+      {
+        "key": "e_1_2_9_130_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1088/1748-6041/10/3/035013"
+      },
+      {
+        "key": "e_1_2_9_131_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbm.b.34130"
+      },
+      {
+        "key": "e_1_2_9_132_1",
+        "first-page": "68",
+        "article-title": "Bone regeneration using bio‐nanocomposite tissue reinforced with bioactive nanoparticles for femoral defect applications in medicine",
+        "volume": "12",
+        "author": "Maghsoudlou M. A.",
+        "year": "2020",
+        "journal-title": "Avicenna Journal of Medical Biotechnology"
+      },
+      {
+        "key": "e_1_2_9_133_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ultsonch.2017.01.022"
+      },
+      {
+        "key": "e_1_2_9_134_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.catcom.2014.05.004"
+      },
+      {
+        "key": "e_1_2_9_135_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1049/mnl.2017.0560"
+      },
+      {
+        "key": "e_1_2_9_136_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1177/0885328219835995"
+      },
+      {
+        "key": "e_1_2_9_137_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1177/0363546512439026"
+      },
+      {
+        "key": "e_1_2_9_138_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2018.03.128"
+      },
+      {
+        "key": "e_1_2_9_139_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.trac.2017.10.005"
+      },
+      {
+        "key": "e_1_2_9_140_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ceramint.2018.10.016"
+      },
+      {
+        "key": "e_1_2_9_141_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s12178-011-9095-6"
+      },
+      {
+        "key": "e_1_2_9_142_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1088/0957-4484/16/10/059"
+      },
+      {
+        "key": "e_1_2_9_143_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jcp.28457"
+      },
+      {
+        "key": "e_1_2_9_144_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3349/ymj.2000.41.6.735"
+      },
+      {
+        "key": "e_1_2_9_145_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1038/sj.ejcn.1601867"
+      },
+      {
+        "key": "e_1_2_9_146_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/S1369-7021(11)70058-X"
+      },
+      {
+        "key": "e_1_2_9_147_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2006.07.034"
+      },
+      {
+        "key": "e_1_2_9_148_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.nano.2011.03.002"
+      },
+      {
+        "key": "e_1_2_9_149_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s10934-013-9757-4"
+      },
+      {
+        "key": "e_1_2_9_150_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ajodo.2011.02.021"
+      },
+      {
+        "key": "e_1_2_9_151_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.11607/jomi.4366"
+      },
+      {
+        "key": "e_1_2_9_152_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1080/10408390500466174"
+      },
+      {
+        "key": "e_1_2_9_153_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/smll.200700378"
+      },
+      {
+        "key": "e_1_2_9_154_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s00264-013-1917-2"
+      },
+      {
+        "key": "e_1_2_9_155_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/adma.200800004"
+      },
+      {
+        "key": "e_1_2_9_156_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2018.12.067"
+      },
+      {
+        "key": "e_1_2_9_157_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.nano.2007.03.005"
+      },
+      {
+        "key": "e_1_2_9_158_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2011.09.016"
+      },
+      {
+        "key": "e_1_2_9_159_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/S0142-9612(02)00352-6"
+      },
+      {
+        "key": "e_1_2_9_160_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s10971-015-3697-1"
+      },
+      {
+        "key": "e_1_2_9_161_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.carbpol.2014.03.041"
+      },
+      {
+        "key": "e_1_2_9_162_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2018.11.256"
+      },
+      {
+        "key": "e_1_2_9_163_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3109/17435390903337693"
+      },
+      {
+        "key": "e_1_2_9_164_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C5RA09560C"
+      },
+      {
+        "key": "e_1_2_9_165_1",
+        "volume-title": "Efeito da incorporação de dióxido de zircônio nanoestruturado em uma resina adesiva experimental",
+        "author": "Provenzi C.",
+        "year": "2014"
+      },
+      {
+        "key": "e_1_2_9_166_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3390/ijms20020435"
+      },
+      {
+        "key": "e_1_2_9_167_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2010.06.051"
+      },
+      {
+        "key": "e_1_2_9_168_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2019.03.092"
+      },
+      {
+        "key": "e_1_2_9_169_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C8NJ01790E"
+      },
+      {
+        "key": "e_1_2_9_170_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.2147/IJN.S194596"
+      },
+      {
+        "key": "e_1_2_9_171_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.carbpol.2019.115696"
+      },
+      {
+        "key": "e_1_2_9_172_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C7PY01701D"
+      },
+      {
+        "key": "e_1_2_9_173_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.carbpol.2018.05.059"
+      },
+      {
+        "key": "e_1_2_9_174_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s00264-010-1154-x"
+      },
+      {
+        "key": "e_1_2_9_175_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.apsusc.2013.09.160"
+      },
+      {
+        "key": "e_1_2_9_176_1",
+        "volume-title": "VI Latin American Congress on Biomedical Engineering CLAIB 2014, Paraná, Argentina 29, 30 & 31 October 2014",
+        "author": "Restrepo N.",
+        "year": "2015"
+      },
+      {
+        "key": "e_1_2_9_177_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.22203/eCM.v015a03"
+      },
+      {
+        "key": "e_1_2_9_178_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jcb.10111"
+      },
+      {
+        "key": "e_1_2_9_179_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1093/jac/dkn034"
+      },
+      {
+        "key": "e_1_2_9_180_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2012.07.036"
+      },
+      {
+        "key": "e_1_2_9_181_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2010.03.058"
+      },
+      {
+        "key": "e_1_2_9_182_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1097/00003086-200211000-00020"
+      },
+      {
+        "key": "e_1_2_9_183_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.4172/1948-593X.1000049"
+      },
+      {
+        "key": "e_1_2_9_184_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1038/7385"
+      },
+      {
+        "key": "e_1_2_9_185_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbm.a.30889"
+      },
+      {
+        "key": "e_1_2_9_186_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1111/hiv.12822"
+      },
+      {
+        "key": "e_1_2_9_187_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1140/epjp/i2019-12375-x"
+      },
+      {
+        "key": "e_1_2_9_188_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2007.06.015"
+      },
+      {
+        "key": "e_1_2_9_189_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jbiosc.2019.04.017"
+      },
+      {
+        "key": "e_1_2_9_190_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/acsami.5b00529"
+      },
+      {
+        "key": "e_1_2_9_191_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2011.04.010"
+      },
+      {
+        "key": "e_1_2_9_192_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/S1079-2104(00)80022-0"
+      },
+      {
+        "key": "e_1_2_9_193_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3390/app8020172"
+      },
+      {
+        "key": "e_1_2_9_194_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ica.2015.07.003"
+      },
+      {
+        "key": "e_1_2_9_195_1",
+        "first-page": "3",
+        "article-title": "Kinetics analysis of electrophoretic deposition using small and large signal modeling: The case study of nano‐mullite suspension",
+        "volume": "4",
+        "author": "Shakeri M. S.",
+        "year": "2016",
+        "journal-title": "Journal of Advanced Materials and Processing"
+      },
+      {
+        "key": "e_1_2_9_196_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/nn300445d"
+      },
+      {
+        "key": "e_1_2_9_197_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1097/00007632-200301150-00008"
+      },
+      {
+        "key": "e_1_2_9_198_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1177/0885328217738006"
+      },
+      {
+        "key": "e_1_2_9_199_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/nn301714n"
+      },
+      {
+        "key": "e_1_2_9_200_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2017.07.078"
+      },
+      {
+        "key": "e_1_2_9_201_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C6RA15267H"
+      },
+      {
+        "key": "e_1_2_9_202_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbio.201400064"
+      },
+      {
+        "key": "e_1_2_9_203_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.apsusc.2010.03.124"
+      },
+      {
+        "key": "e_1_2_9_204_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.etap.2015.02.003"
+      },
+      {
+        "key": "e_1_2_9_205_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/jbm.a.36707"
+      },
+      {
+        "key": "e_1_2_9_206_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/cmdc.200600171"
+      },
+      {
+        "key": "e_1_2_9_207_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.jtemb.2017.05.002"
+      },
+      {
+        "key": "e_1_2_9_208_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1155/2013/465086"
+      },
+      {
+        "key": "e_1_2_9_209_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ijbiomac.2011.11.013"
+      },
+      {
+        "key": "e_1_2_9_210_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/S0140-6736(99)90247-7"
+      },
+      {
+        "key": "e_1_2_9_211_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.addr.2009.11.002"
+      },
+      {
+        "key": "e_1_2_9_212_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.arthro.2013.02.025"
+      },
+      {
+        "key": "e_1_2_9_213_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C5RA13556G"
+      },
+      {
+        "key": "e_1_2_9_214_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/btpr.2469"
+      },
+      {
+        "key": "e_1_2_9_215_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2013.08.009"
+      },
+      {
+        "key": "e_1_2_9_216_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.nano.2015.02.013"
+      },
+      {
+        "key": "e_1_2_9_217_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2012.09.021"
+      },
+      {
+        "key": "e_1_2_9_218_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/acsami.5b02893"
+      },
+      {
+        "key": "e_1_2_9_219_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2011.04.006"
+      },
+      {
+        "key": "e_1_2_9_220_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2009.09.021"
+      },
+      {
+        "key": "e_1_2_9_221_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1557/jmr.2015.243"
+      },
+      {
+        "key": "e_1_2_9_222_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1166/jbn.2012.1437"
+      },
+      {
+        "key": "e_1_2_9_223_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1002/marc.201800062"
+      },
+      {
+        "key": "e_1_2_9_224_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/b712179m"
+      },
+      {
+        "key": "e_1_2_9_225_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/0142-9612(96)85753-X"
+      },
+      {
+        "key": "e_1_2_9_226_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1088/0957-4484/24/39/395101"
+      },
+      {
+        "key": "e_1_2_9_227_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.actbio.2011.06.028"
+      },
+      {
+        "key": "e_1_2_9_228_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.carbon.2015.04.048"
+      },
+      {
+        "key": "e_1_2_9_229_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2012.09.066"
+      },
+      {
+        "key": "e_1_2_9_230_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/c3tb20261e"
+      },
+      {
+        "key": "e_1_2_9_231_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2018.12.120"
+      },
+      {
+        "key": "e_1_2_9_232_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C5NR01107H"
+      },
+      {
+        "key": "e_1_2_9_233_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/nl301934w"
+      },
+      {
+        "key": "e_1_2_9_234_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C5NR07023F"
+      },
+      {
+        "key": "e_1_2_9_235_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C6TB01282E"
+      },
+      {
+        "key": "e_1_2_9_236_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.2147/IJN.S184396"
+      },
+      {
+        "key": "e_1_2_9_237_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.13005/ojc/310173"
+      },
+      {
+        "key": "e_1_2_9_238_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.surfcoat.2006.07.058"
+      },
+      {
+        "key": "e_1_2_9_239_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.apsusc.2014.07.027"
+      },
+      {
+        "key": "e_1_2_9_240_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2012.10.058"
+      },
+      {
+        "key": "e_1_2_9_241_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.matlet.2014.09.078"
+      },
+      {
+        "key": "e_1_2_9_242_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.polymertesting.2019.03.008"
+      },
+      {
+        "key": "e_1_2_9_243_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.bios.2017.08.018"
+      },
+      {
+        "key": "e_1_2_9_244_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.biomaterials.2011.03.053"
+      },
+      {
+        "key": "e_1_2_9_245_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/nn101373r"
+      },
+      {
+        "key": "e_1_2_9_246_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ceramint.2019.11.282"
+      },
+      {
+        "key": "e_1_2_9_247_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.3390/ijms13055554"
+      },
+      {
+        "key": "e_1_2_9_248_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1007/s12274-016-1265-9"
+      },
+      {
+        "key": "e_1_2_9_249_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2014.04.042"
+      },
+      {
+        "key": "e_1_2_9_250_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C4TB01063A"
+      },
+      {
+        "key": "e_1_2_9_251_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.watres.2012.01.015"
+      },
+      {
+        "key": "e_1_2_9_252_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.nano.2015.07.016"
+      },
+      {
+        "key": "e_1_2_9_253_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1038/ncomms10376"
+      },
+      {
+        "key": "e_1_2_9_254_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.2147/IJN.S21657"
+      },
+      {
+        "key": "e_1_2_9_255_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.ceramint.2013.01.094"
+      },
+      {
+        "key": "e_1_2_9_256_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1039/C6TB00390G"
+      },
+      {
+        "key": "e_1_2_9_257_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.colsurfb.2018.11.003"
+      },
+      {
+        "key": "e_1_2_9_258_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1016/j.msec.2019.109764"
+      },
+      {
+        "key": "e_1_2_9_259_1",
+        "doi-asserted-by": "publisher",
+        "DOI": "10.1021/acsbiomaterials.8b00986"
+      },
+      {
+        "key": "e_1_2_9_260_1",
+        "first-page": "475",
+        "article-title": "Role of prostaglandin E1 and copper in angiogenesis",
+        "volume": "69",
+        "author": "Ziche M.",
+        "year": "1982",
+        "journal-title": "Journal of the National Cancer Institute"
+      }
+    ],
+    "container-title": [
+      "Journal of Tissue Engineering and Regenerative Medicine"
+    ],
     "original-title": [],
     "language": "en",
-    "link": [{
-      "URL": "https://onlinelibrary.wiley.com/doi/pdf/10.1002/term.3131",
-      "content-type": "application/pdf",
-      "content-version": "vor",
-      "intended-application": "text-mining"
-    }, {
-      "URL": "https://onlinelibrary.wiley.com/doi/full-xml/10.1002/term.3131",
-      "content-type": "application/xml",
-      "content-version": "vor",
-      "intended-application": "text-mining"
-    }, {
-      "URL": "https://onlinelibrary.wiley.com/doi/pdf/10.1002/term.3131",
-      "content-type": "unspecified",
-      "content-version": "vor",
-      "intended-application": "similarity-checking"
-    }],
+    "link": [
+      {
+        "URL": "https://onlinelibrary.wiley.com/doi/pdf/10.1002/term.3131",
+        "content-type": "application/pdf",
+        "content-version": "vor",
+        "intended-application": "text-mining"
+      },
+      {
+        "URL": "https://onlinelibrary.wiley.com/doi/full-xml/10.1002/term.3131",
+        "content-type": "application/xml",
+        "content-version": "vor",
+        "intended-application": "text-mining"
+      },
+      {
+        "URL": "https://onlinelibrary.wiley.com/doi/pdf/10.1002/term.3131",
+        "content-type": "unspecified",
+        "content-version": "vor",
+        "intended-application": "similarity-checking"
+      }
+    ],
     "deposited": {
       "date-parts": [
-        [2020, 12, 24]
+        [
+          2020,
+          12,
+          24
+        ]
       ],
       "date-time": "2020-12-24T18:31:16Z",
       "timestamp": 1608834676000
@@ -1297,7 +1640,11 @@
     "short-title": [],
     "issued": {
       "date-parts": [
-        [2020, 9, 30]
+        [
+          2020,
+          9,
+          30
+        ]
       ]
     },
     "references-count": 259,
@@ -1305,55 +1652,80 @@
       "issue": "12",
       "published-print": {
         "date-parts": [
-          [2020, 12]
+          [
+            2020,
+            12
+          ]
         ]
       }
     },
-    "alternative-id": ["10.1002/term.3131"],
+    "alternative-id": [
+      "10.1002/term.3131"
+    ],
     "URL": "http://dx.doi.org/10.1002/term.3131",
-    "archive": ["Portico"],
+    "archive": [
+      "Portico"
+    ],
     "relation": {},
-    "ISSN": ["1932-6254", "1932-7005"],
-    "issn-type": [{
-      "value": "1932-6254",
-      "type": "print"
-    }, {
-      "value": "1932-7005",
-      "type": "electronic"
-    }],
-    "subject": ["Biomedical Engineering", "Biomaterials", "Medicine (miscellaneous)"],
+    "ISSN": [
+      "1932-6254",
+      "1932-7005"
+    ],
+    "issn-type": [
+      {
+        "value": "1932-6254",
+        "type": "print"
+      },
+      {
+        "value": "1932-7005",
+        "type": "electronic"
+      }
+    ],
+    "subject": [
+      "Biomedical Engineering",
+      "Biomaterials",
+      "Medicine (miscellaneous)"
+    ],
     "published": {
       "date-parts": [
-        [2020, 9, 30]
+        [
+          2020,
+          9,
+          30
+        ]
       ]
     },
-    "assertion": [{
-      "value": "2020-03-27",
-      "order": 0,
-      "name": "received",
-      "label": "Received",
-      "group": {
-        "name": "publication_history",
-        "label": "Publication History"
+    "assertion": [
+      {
+        "value": "2020-03-27",
+        "order": 0,
+        "name": "received",
+        "label": "Received",
+        "group": {
+          "name": "publication_history",
+          "label": "Publication History"
+        }
+      },
+      {
+        "value": "2020-09-03",
+        "order": 1,
+        "name": "accepted",
+        "label": "Accepted",
+        "group": {
+          "name": "publication_history",
+          "label": "Publication History"
+        }
+      },
+      {
+        "value": "2020-09-30",
+        "order": 2,
+        "name": "published",
+        "label": "Published",
+        "group": {
+          "name": "publication_history",
+          "label": "Publication History"
+        }
       }
-    }, {
-      "value": "2020-09-03",
-      "order": 1,
-      "name": "accepted",
-      "label": "Accepted",
-      "group": {
-        "name": "publication_history",
-        "label": "Publication History"
-      }
-    }, {
-      "value": "2020-09-30",
-      "order": 2,
-      "name": "published",
-      "label": "Published",
-      "group": {
-        "name": "publication_history",
-        "label": "Publication History"
-      }
-    }]
+    ]
   }
 }

--- a/tests/fixtures/dspace_metadata.json
+++ b/tests/fixtures/dspace_metadata.json
@@ -78,7 +78,7 @@
     },
     {
       "key": "dc.title",
-      "value": "Metal‐based nanoparticles for bone tissue engineering"
+      "value": "Metal nanoparticles for bone tissue engineering"
     },
     {
       "key": "dc.relation.isversionof",

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -10,21 +10,17 @@ def test_get_dois_from_spreadsheet():
 def test_get_crossref_work_from_doi(mocked_web):
     doi = "10.1002/term.3131"
     work = crossref.get_work_record_from_doi("http://example.com/works/", doi)
-    assert work["message"]["title"] == [
-        "Metal‐based nanoparticles for bone tissue engineering"
-    ]
+    assert work["message"]["title"] == ["Metal nanoparticles for bone tissue engineering"]
 
 
-def test_get_metadata_extract_from(
-    mocked_web, crossref_value_dict, crossref_work_record
-):
+def test_get_metadata_extract_from(mocked_web, crossref_value_dict, crossref_work_record):
     value_dict = crossref.get_metadata_extract_from(crossref_work_record)
     assert value_dict == crossref_value_dict
 
 
 def test_create_dspace_metadata_from_dict_minimum_metadata():
     value_dict = {
-        "title": "Metal‐based nanoparticles for bone tissue engineering",
+        "title": "Metal nanoparticles for bone tissue engineering",
         "URL": "http://dx.doi.org/10.1002/term.3131",
     }
     metadata = crossref.create_dspace_metadata_from_dict(
@@ -33,7 +29,7 @@ def test_create_dspace_metadata_from_dict_minimum_metadata():
     assert metadata["metadata"] == [
         {
             "key": "dc.title",
-            "value": "Metal‐based nanoparticles for bone tissue engineering",
+            "value": "Metal nanoparticles for bone tissue engineering",
         },
         {
             "key": "dc.relation.isversionof",

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1,9 +1,10 @@
+from awd.config import STATUS_CODE_200
 from awd.status import Status
 
 
 def test_dynamodb_add_doi_item_to_database(mocked_dynamodb, dynamodb_class):
     add_response = dynamodb_class.add_doi_item_to_database("test_dois", "222.2/2222")
-    assert add_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert add_response["ResponseMetadata"]["HTTPStatusCode"] == STATUS_CODE_200
 
 
 def test_dynamodb_retrieve_doi_items_from_database(mocked_dynamodb, dynamodb_class):
@@ -37,9 +38,7 @@ def test_dynamodb_retry_threshold_exceeded_false(mocked_dynamodb, dynamodb_class
             "last_modified": {"S": "2022-01-28 10:28:53"},
         },
     )
-    validation_status = dynamodb_class.attempts_exceeded(
-        "test_dois", "111.1/1111", "10"
-    )
+    validation_status = dynamodb_class.attempts_exceeded("test_dois", "111.1/1111", "10")
     assert validation_status is False
 
 
@@ -53,9 +52,7 @@ def test_dynamodb_retry_threshold_exceeded_true(mocked_dynamodb, dynamodb_class)
             "last_modified": {"S": "2022-01-28 10:28:53"},
         },
     )
-    validation_status = dynamodb_class.attempts_exceeded(
-        "test_dois", "111.1/1111", "10"
-    )
+    validation_status = dynamodb_class.attempts_exceeded("test_dois", "111.1/1111", "10")
     assert validation_status is True
 
 
@@ -80,7 +77,7 @@ def test_dynamodb_update_doi_item_attempts_in_database(mocked_dynamodb, dynamodb
     update_response = dynamodb_class.update_doi_item_attempts_in_database(
         "test_dois", "111.1/1111"
     )
-    assert update_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert update_response["ResponseMetadata"]["HTTPStatusCode"] == STATUS_CODE_200
     updated_item = dynamodb_class.client.get_item(
         TableName="test_dois",
         Key={"doi": {"S": "111.1/1111"}},
@@ -112,7 +109,7 @@ def test_dynamodb_update_doi_item_status_in_database(mocked_dynamodb, dynamodb_c
     update_response = dynamodb_class.update_doi_item_status_in_database(
         "test_dois", "111.1/1111", Status.MESSAGE_SENT.value
     )
-    assert update_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert update_response["ResponseMetadata"]["HTTPStatusCode"] == STATUS_CODE_200
     updated_item = dynamodb_class.client.get_item(
         TableName="test_dois",
         Key={"doi": {"S": "111.1/1111"}},

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,7 +1,7 @@
 import pytest
 from botocore.exceptions import ClientError
 
-from awd import s3
+from awd.config import STATUS_CODE_200
 
 
 def test_s3_filter_files_in_bucket_with_matching_csv(mocked_s3, s3_class):
@@ -44,7 +44,7 @@ def test_archive_file_in_bucket(mocked_s3, s3_class):
         " specified key does not exist." in str(e.value)
     )
     response = s3_class.client.get_object(Bucket="awd", Key="archived/test.csv")
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == STATUS_CODE_200
 
 
 def test_s3_put_file(mocked_s3, s3_class):
@@ -55,6 +55,4 @@ def test_s3_put_file(mocked_s3, s3_class):
         "test.json",
     )
     assert len(s3_class.client.list_objects(Bucket="awd")["Contents"]) == 1
-    assert (
-        s3_class.client.list_objects(Bucket="awd")["Contents"][0]["Key"] == "test.json"
-    )
+    assert s3_class.client.list_objects(Bucket="awd")["Contents"][0]["Key"] == "test.json"

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,5 +1,7 @@
 from email.mime.multipart import MIMEMultipart
 
+from awd.config import STATUS_CODE_200
+
 
 def test_ses_create_email(ses_class):
     message = ses_class.create_email(
@@ -18,4 +20,4 @@ def test_ses_send_email(mocked_ses, ses_class):
         "test@example.com",
         message,
     )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == STATUS_CODE_200

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -2,6 +2,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from awd import sqs
+from awd.config import STATUS_CODE_200
 
 
 def test_sqs_delete_success(
@@ -23,7 +24,7 @@ def test_sqs_delete_success(
     response = sqs_class.delete(
         "https://queue.amazonaws.com/123456789012/", "mock-output-queue", receipt_handle
     )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == STATUS_CODE_200
 
 
 def test_sqs_delete_failure(mocked_sqs, sqs_class):
@@ -55,11 +56,9 @@ def test_sqs_receive_success(
 
 def test_sqs_receive_failure(mocked_sqs, sqs_class):
     with pytest.raises(ClientError):
-        messages = sqs_class.receive(
-            "https://queue.amazonaws.com/123456789012/", "non-existent"
+        next(
+            sqs_class.receive("https://queue.amazonaws.com/123456789012/", "non-existent")
         )
-        for message in messages:
-            pass
 
 
 def test_sqs_send_success(
@@ -71,7 +70,7 @@ def test_sqs_send_success(
         submission_message_attributes,
         submission_message_body,
     )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == STATUS_CODE_200
 
 
 def test_sqs_send_failure(


### PR DESCRIPTION
#### Helpful background context
Adding `ruff` and associated changes as well as pre-commit hooks and `dependabot.yml`

#### How can a reviewer manually see the effects of these changes?
As these are just linting updates, they can be verified by checking the CI workflow under the repo's `Actions` tab or cloning the repo and verifying that `make test` and `make lint` still pass.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/IN-891

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
